### PR TITLE
Feature/26 fix cloud masking method

### DIFF
--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -71,6 +71,7 @@ def main():
                       default="gee_img.png")
     parser.add_argument("--input_file",help="text file with coordinates, one per line")
     parser.add_argument("--mask_cloud",help="EXPERIMENTAL - apply cloud masking function",action='store_true')
+    parser.add_argument("--network_centrality",help="EXPERIMENTAL - apply cloud masking function",action='store_true')
 
     args = parser.parse_args()
     sanity_check_args(args)
@@ -84,7 +85,9 @@ def main():
     region_size = args.region_size
     scale = args.scale
     mask_cloud = True if args.mask_cloud else False
-    input_file = arg.input_file if args.input_file else None
+    network_centrality = True if args.network_centrality else False
+
+    input_file = args.input_file if args.input_file else None
     num_time_points = args.num_time_points
     if args.coords_point:
         coords = [float(x) for x in args.coords_point.split(",")]
@@ -105,7 +108,10 @@ def main():
                     end_date,
                     mask_cloud,
                     output_dir,
-                    output_suffix)
+                    output_suffix,
+                    network_centrality)
+
+
     print("Done")
 
 

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -71,7 +71,7 @@ def main():
                       default="gee_img.png")
     parser.add_argument("--input_file",help="text file with coordinates, one per line")
     parser.add_argument("--mask_cloud",help="EXPERIMENTAL - apply cloud masking function",action='store_true')
-    parser.add_argument("--network_centrality",help="EXPERIMENTAL - apply cloud masking function",action='store_true')
+    parser.add_argument("--network_centrality",help="calculate network centrality measures on images and print them out as json files",action='store_true')
 
     args = parser.parse_args()
     sanity_check_args(args)

--- a/pyveg/src/gee_interface.py
+++ b/pyveg/src/gee_interface.py
@@ -38,11 +38,12 @@ def apply_mask_cloud(image, input_coll):
     Different input_collections need different steps to be taken to filter
     out cloud.
     """
-    if "LANDSAT" in input_coll:
-        mask_func = cloud_mask.landsat8ToaBQA()
-        return mask_func(image)
+    if input_coll=='LANDSAT/LC08/C01/T1_SR':
+        mask_func = cloud_mask.landsat8SRPixelQA()
+        image = image.map(mask_func)
+        return image
 
-    elif "COPERNICUS" in input_coll:
+    elif input_coll=='COPERNICUS/S2':
         mask_func = cloud_mask.sentinel2()
         image = image.filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE",20)).map(mask_func)
         return image

--- a/pyveg/src/gee_interface.py
+++ b/pyveg/src/gee_interface.py
@@ -124,7 +124,7 @@ def get_download_urls(coords, # [long,lat]
     .filterDate(start_date, end_date)
 
     if mask_cloud:
-        image = apply_mask_cloud(dataset, image_collection)
+        dataset = apply_mask_cloud(dataset, image_collection)
 
     image = dataset.median()
 

--- a/pyveg/src/satellite_data_analysis.py
+++ b/pyveg/src/satellite_data_analysis.py
@@ -107,7 +107,7 @@ def process_coords(coords,
                    scale, # size of each pixel in output image (in m)
                    start_date,
                    end_date,
-                   mask_cloud=True, ## EXPERIMENTAL - false by default
+                   mask_cloud=False, ## EXPERIMENTAL - false by default
                    output_dir=".",
                    output_suffix="_gee.png",
                    network_centrality=False,

--- a/pyveg/src/satellite_data_analysis.py
+++ b/pyveg/src/satellite_data_analysis.py
@@ -141,9 +141,13 @@ def process_coords(coords,
         # into RGB image files in our chosen output directory
         for tif_filebase in tif_filebases:
             merged_image = combine_tif(tif_filebase, bands)
+            bw_image = convert_to_bw(merged_image,470)
+
             output_filename = os.path.basename(tif_filebase)
             output_filename += "_{0:.3f}_{1:.3f}".format(coords[0], coords[1])
-            output_filename += "_{}".format(output_suffix)
+            output_filename += "_10kmLargeImage{}".format(output_suffix)
+            save_image(bw_image, output_dir, output_filename)
+
             ## if requested, divide into smaller sub-images
             sub_images = crop_image_npix(merged_image,
                                              sub_image_size[0],
@@ -161,6 +165,7 @@ def process_coords(coords,
                 save_image(sub_image, output_dir, output_filename)
 
                 if network_centrality:
+                    print ('Calculating network centrality metrics')
 
                     image_array = from_image_to_array(sub_image)
                     feature_vec, sel_pixels = subgraph_centrality(image_array)
@@ -221,6 +226,7 @@ def get_time_series(num_time_periods,
                     end_date,
                     mask_cloud=False, ## EXPERIMENTAL - false by default
                     output_dir=".",
+                    output_suffix=".",#end of output filename, including file extension" # DOESNT SEEM TO BE USED
                     network_centrality = False,
                     sub_image_size=[50,50]):
     """

--- a/pyveg/src/satellite_data_analysis.py
+++ b/pyveg/src/satellite_data_analysis.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 
 
 from .gee_interface import (
-    mask_cloud,
+    apply_mask_cloud,
     add_NDVI,
     download_and_unzip,
     get_download_urls
@@ -107,7 +107,7 @@ def process_coords(coords,
                    scale, # size of each pixel in output image (in m)
                    start_date,
                    end_date,
-                   mask_cloud=False, ## EXPERIMENTAL - false by default
+                   mask_cloud=True, ## EXPERIMENTAL - false by default
                    output_dir=".",
                    output_suffix="_gee.png",
                    network_centrality=False,

--- a/pyveg/src/subgraph_centrality.py
+++ b/pyveg/src/subgraph_centrality.py
@@ -165,6 +165,9 @@ def feature_vector_metrics(feature_vector,output_csv=None):
     # difference between last and first indexes
     feature_vec_metrics['offset'] = (feature_vector[-1] - feature_vector[0])
 
+    # difference between last and middle indexes
+    feature_vec_metrics['offset50'] = (feature_vector[-1] - feature_vector[len(feature_vector)//2])
+
     # mean value on the feature_vector
     feature_vec_metrics['mean'] = np.mean(feature_vector)
 
@@ -177,7 +180,6 @@ def feature_vector_metrics(feature_vector,output_csv=None):
         write_dict_to_csv(feature_vec_metrics, output_csv)
 
     return feature_vec_metrics
-
 
 
 


### PR DESCRIPTION
Fixing masking cloud as in issue #26. Changes:

- The masking now work for COPERNICUS/S2 and LANDSAT/LC08/C01/T1_SR. For other satellites we would have to implement the right function. 
- The script analyse_gee_data.py now also prints the 10x10 Km figure for reference, in addition to the smaller ones. 
- Small fixes, such as adding the --network_centrality option in the arguments.

I tested the cloud masking on the UK, and compared it with the output of the CodeEditor in the same place, same period of time and similar threshold. It looks like its doing what is expected.
There are still some issues that I think are linked to the thresholding, and not the cloud coverage. 