### PR TITLE
Improve output of analyse_gee_data

### DIFF
--- a/pyveg/config.py
+++ b/pyveg/config.py
@@ -9,9 +9,9 @@ date_range = ('2016-01-01', '2016-01-11')
 
 num_days_per_point = 10
 
-collections_to_use = ['Copernicus', 'Landsat', 'NASA']
+collections_to_use = ['Copernicus']
 
-do_network_centrality = False
+do_network_centrality = True
 
 data_collections = {
     'Copernicus' : {

--- a/pyveg/config.py
+++ b/pyveg/config.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-output_dir = 'TEST_OUT'
+output_dir = 'TEST'
 
 coordinates = (27.99,11.29) # initial
 #coordinates = (28.37,11.12) # labyrinths
  
-date_range = ('2016-01-01', '2017-01-01')
+date_range = ('2016-01-01', '2016-01-11')
 
-num_days_per_point = 30
+num_days_per_point = 10
 
-collections_to_use = ['Copernicus']
+collections_to_use = ['Copernicus', 'Landsat', 'NASA']
 
 do_network_centrality = False
 
@@ -39,7 +39,6 @@ data_collections = {
         'collection_name': 'NASA/GPM_L3/IMERG_V06',
         'type': 'weather',
         'precipitation_band': ['precipitationCal'],
-        'temperature_band': ['probabilityLiquidPrecipitation']
     },
     'unsupported' : {
         'collection_name': "ECMWF/ERA5/DAILY",

--- a/pyveg/config.py
+++ b/pyveg/config.py
@@ -9,9 +9,9 @@ date_range = ('2016-01-01', '2017-01-01')
 
 num_days_per_point = 30
 
-collections_to_use = ['unsupported']
+collections_to_use = ['Copernicus']
 
-do_network_centrality = True
+do_network_centrality = False
 
 data_collections = {
     'Copernicus' : {

--- a/pyveg/config.py
+++ b/pyveg/config.py
@@ -50,5 +50,6 @@ data_collections = {
 
 data_collections = {key : value for key,value in data_collections.items() if key in collections_to_use}
 
-cloudy_pixel_percent = 10
+# not currently used
+# cloudy_pixel_percent = 10 
 

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -89,11 +89,6 @@ def main():
     print('Running analyse_gee_data.py')
     print('-'*35)
 
-    print('The following collections will be used:')
-    for name, collection_dict in config.data_collections.items():
-        print(collection_dict)
-    print('\n')
-
     # run!
     process_all_collections(config.output_dir,
                             config.data_collections,

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -32,8 +32,11 @@ pip install --upgrade pillow
 import os
 import argparse
 import warnings
+import time
+from shutil import copyfile
 from pyveg.src.satellite_data_analysis import process_all_collections
 from pyveg import config
+
 
 def main():
     """
@@ -69,6 +72,15 @@ def main():
         coordinates = args.coordinates.split(',')
         config.coordinates = (float(coordinates[0]), float(coordinates[1]))
 
+    # parse output directory 
+    config.output_dir += '__' + time.strftime("%Y-%m-%d_%H-%M-%S") 
+    config.output_dir = os.path.join('output', config.output_dir) # force into .gitignore
+
+    # before we run anythin, save the current config to the output dir
+    if not os.path.exists(config.output_dir):
+        os.makedirs(config.output_dir, exist_ok=True)
+    copyfile(config.__file__, os.path.join(config.output_dir, 'config_cached.py'))
+
     # print which collections we are running with
     print('-'*35)
     print('Running analyse_gee_data.py')
@@ -78,7 +90,8 @@ def main():
     for name, collection_dict in config.data_collections.items():
         print(collection_dict)
     print('\n')
-    print(config.num_days_per_point)
+
+    # run!
     process_all_collections(config.output_dir,
                             config.data_collections,
                             config.coordinates,

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -30,7 +30,6 @@ pip install --upgrade pillow
 """
 
 import os
-
 import argparse
 import warnings
 from pyveg.src.satellite_data_analysis import process_all_collections
@@ -46,37 +45,47 @@ def main():
     python analyse_gee_data.py \\
         --start_date 2016-01-01 \\
         --end_date 2019-01-01 \\
-        --coords 27.99,11.2878 \\
+        --coords 27.99,11.29 \\
     """
+
+    # crate argparse
     parser = argparse.ArgumentParser(description="download from EE", epilog=example_command, 
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--start_date",help="YYYY-MM-DD", default="2013-03-30")
-    parser.add_argument("--end_date",help="YYYY-MM-DD", default="2013-04-01")
-    parser.add_argument("--coords",help="'long,lat'")
+
+    # add arguments - keep it minimal here, but overwrite value from config 
+    # if option is given here
+    parser.add_argument("--start_date",help="YYYY-MM-DD")
+    parser.add_argument("--end_date",help="YYYY-MM-DD")
+    parser.add_argument("--coordinates",help="'long,lat'")
 
     args = parser.parse_args()
 
-    start_date = args.start_date
-    end_date = args.end_date
+    # overwrite dates if specified
+    if args.start_date is not None and args.end_date is not None:
+        config.date_range = (args.start_date, args.end_date)
 
-    coords = [float(x) for x in args.coords.split(",")]
-    
-    input_collections = config.data_collections
-    print('Running with the following collections:')
-    for name, collection_dict in input_collections.items():
+    # overwrite coords if specified
+    if args.coordinates is not None:
+        coordinates = args.coordinates.split(',')
+        config.coordinates = (float(coordinates[0]), float(coordinates[1]))
+
+    # print which collections we are running with
+    print('-'*35)
+    print('Running analyse_gee_data.py')
+    print('-'*35)
+
+    print('The following collections will be used:')
+    for name, collection_dict in config.data_collections.items():
         print(collection_dict)
     print('\n')
-
-    output_dir = config.output_dir
-
-    process_all_collections(output_dir,
-                            input_collections,
-                            coords,
-                            (start_date,end_date),
+    print(config.num_days_per_point)
+    process_all_collections(config.output_dir,
+                            config.data_collections,
+                            config.coordinates,
+                            config.date_range,
                             config.num_days_per_point)
 
-
-    print('Done!')
+    print('Finished all.')
 
 
 if __name__ == "__main__":

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -43,7 +43,10 @@ def main():
     use command line arguments to choose images.
     """
 
-    example_command = """Example usage:
+    help_text = """Options should be specified in the config 
+    file where possible, but can be overwritten using this CLI.
+    
+    Example usage:
 
     python analyse_gee_data.py \\
         --start_date 2016-01-01 \\
@@ -52,7 +55,7 @@ def main():
     """
 
     # crate argparse
-    parser = argparse.ArgumentParser(description="download from EE", epilog=example_command, 
+    parser = argparse.ArgumentParser(description="download from EE", epilog=help_text, 
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
 
     # add arguments - keep it minimal here, but overwrite value from config 
@@ -98,7 +101,7 @@ def main():
                             config.date_range,
                             config.num_days_per_point)
 
-    print('Finished all.')
+    print('\nFinished all.')
 
 
 if __name__ == "__main__":

--- a/pyveg/src/image_utils.py
+++ b/pyveg/src/image_utils.py
@@ -543,7 +543,7 @@ def adaptive_threshold(img):
     return img_thresh
 
 
-def process_image(img, r=3):
+def process_and_threshold(img, r=3):
     """
     Perform histogram equalisation, adaptive thresholding, and median
     filtering on an input PIL Image. Return the result converted

--- a/pyveg/src/image_utils.py
+++ b/pyveg/src/image_utils.py
@@ -32,7 +32,7 @@ def save_json(out_dict, output_dir, output_filename):
     output_path = os.path.join(output_dir, output_filename)
 
     with open(output_path, 'w') as fp:
-        json.dump(out_dict, fp)
+        json.dump(out_dict, fp, indent=2)
 
     print("Saved json file '{}'".format(output_path))
 

--- a/pyveg/src/image_utils.py
+++ b/pyveg/src/image_utils.py
@@ -560,3 +560,33 @@ def process_and_threshold(img, r=3):
 
     return numpy_to_pillow(img)
 # ---------------------------------------------------------------------
+
+
+def check_image_ok(rgb_image):
+    """
+    Check the quality of an RGB image. Currently checking if we have 
+    > 10% pixels being masked. This indicates problems with cloud masking
+    in previous steps.
+
+    Parameters
+    ----------
+    rgb_image : Pillow.Image
+        Input image to check the quality of
+
+    Returns
+    ---------- 
+    bool
+        `True` if image passes quality requirements, 
+        else `False`.
+    """
+
+    img_array = pillow_to_numpy(rgb_image)
+    
+    black = [0,0,0]
+    black_pix_threshold = 0.1
+    n_black_pix = np.count_nonzero(np.all(img_array == black, axis=2))
+
+    if n_black_pix / (img_array.shape[0]*img_array.shape[1]) > black_pix_threshold:
+        return False
+    else:
+        return True

--- a/pyveg/src/satellite_data_analysis.py
+++ b/pyveg/src/satellite_data_analysis.py
@@ -452,6 +452,9 @@ def get_time_series(num_time_periods,
 
 def process_single_collection(output_dir, collection_dict, coords, date_range, n_days_per_slice, region_size=0.1, scale=10):
 
+    print(f'''\nProcessing collection "{collection_dict['collection_name']}".''')
+    print('-'*50)
+
     # unpack date range
     start_date, end_date = date_range
 
@@ -462,10 +465,14 @@ def process_single_collection(output_dir, collection_dict, coords, date_range, n
     # for each time interval
     for date_range in date_ranges:
         
+        print(f'Looking for data in the date range {date_range}...')
+        
         if collection_dict['type'] == 'vegetation':
             get_vegetation(output_dir, collection_dict, coords, date_range, region_size, scale)
         else:
             get_weather(output_dir, collection_dict, coords, date_range, region_size, scale)
+
+    print(f'''Finished processing collection "{collection_dict['collection_name']}".''')
 
             
 

--- a/pyveg/src/satellite_data_analysis.py
+++ b/pyveg/src/satellite_data_analysis.py
@@ -121,12 +121,6 @@ def construct_image_savepath(output_dir, collection_name, coords, date_range, im
     stamped images in this dir.
     """
 
-    # make a new dir inside `output_dir`
-    output_subdir = os.path.join(output_dir, collection_name.split('/')[0])
-
-    if not os.path.exists(output_subdir):
-        os.makedirs(output_subdir, exist_ok=True)
-
     # get the mid point of the date range
     mid_period_string = find_mid_period(date_range[0], date_range[1])
 
@@ -134,7 +128,7 @@ def construct_image_savepath(output_dir, collection_name, coords, date_range, im
     filename = f'{mid_period_string}_{coords[0]}-{coords[1]}_{image_type}.png'
 
     # full path is dir + filename
-    full_path = os.path.join(output_subdir, filename)
+    full_path = os.path.join(output_dir, filename)
 
     return full_path
 
@@ -353,7 +347,7 @@ def get_vegetation(output_dir, collection_dict, coords, date_range, region_size=
         for image in sub_images:
 
             # histogram eq and adaptive thesholding
-            sub_image = process_image(image[0]) 
+            sub_image = process_image(image[0])
 
             sub_coords = image[1]
             output_filename = os.path.basename(tif_filebase)
@@ -451,9 +445,17 @@ def get_time_series(num_time_periods,
 
 
 def process_single_collection(output_dir, collection_dict, coords, date_range, n_days_per_slice, region_size=0.1, scale=10):
+    """
+    Process all dates for a single Earth Engine collection.
+    """
 
     print(f'''\nProcessing collection "{collection_dict['collection_name']}".''')
     print('-'*50)
+
+    # make a new dir inside `output_dir`
+    output_subdir = os.path.join(output_dir, collection_dict['collection_name'].split('/')[0])
+    if not os.path.exists(output_subdir):
+        os.makedirs(output_subdir, exist_ok=True)
 
     # unpack date range
     start_date, end_date = date_range
@@ -464,19 +466,21 @@ def process_single_collection(output_dir, collection_dict, coords, date_range, n
 
     # for each time interval
     for date_range in date_ranges:
-        
+
         print(f'Looking for data in the date range {date_range}...')
         
         if collection_dict['type'] == 'vegetation':
-            get_vegetation(output_dir, collection_dict, coords, date_range, region_size, scale)
+            get_vegetation(output_subdir, collection_dict, coords, date_range, region_size, scale)
         else:
-            get_weather(output_dir, collection_dict, coords, date_range, region_size, scale)
+            get_weather(output_subdir, collection_dict, coords, date_range, region_size, scale)
 
     print(f'''Finished processing collection "{collection_dict['collection_name']}".''')
 
-            
 
 def process_all_collections(output_dir, collections, coords, date_range, n_days_per_slice, region_size=0.1, scale=10):
+    """
+    Process all dates for all specified Earth Engine collections.
+    """
 
     for _, collection_dict in collections.items(): # possible to parallelise?
 

--- a/pyveg/src/satellite_data_analysis.py
+++ b/pyveg/src/satellite_data_analysis.py
@@ -23,7 +23,8 @@ from .image_utils import (
     scale_tif,
     save_json,
     pillow_to_numpy,
-    process_and_threshold
+    process_and_threshold,
+    check_image_ok
 )
 
 from .subgraph_centrality import (
@@ -264,35 +265,6 @@ def process_coords(coords,
                     output_filename += '.json'
                     save_json(feature_vec_metrics, output_dir, output_filename)
 '''
-
-def check_image_ok(rgb_image):
-    """
-    Check the quality of an RGB image. Currently checking if we have 
-    > 10% pixels being masked. This indicates problems with cloud masking
-    in previous steps.
-
-    Parameters
-    ----------
-    rgb_image : Pillow.Image
-        Input image to check the quality of
-
-    Returns
-    ---------- 
-    bool
-        `True` if image passes quality requirements, 
-        else `False`.
-    """
-
-    img_array = pillow_to_numpy(rgb_image)
-    
-    black = [0,0,0]
-    black_pix_threshold = 0.1
-    n_black_pix = np.count_nonzero(np.all(img_array == black, axis=2))
-
-    if n_black_pix / (img_array.shape[0]*img_array.shape[1]) > black_pix_threshold:
-        return False
-    else:
-        return True
 
 
 def run_network_centrality(output_dir, image, coords, date_range, region_size, sub_image_size=[50,50]):

--- a/pyveg/src/satellite_data_analysis.py
+++ b/pyveg/src/satellite_data_analysis.py
@@ -101,20 +101,6 @@ def get_num_n_day_slices(start_date, end_date, days_per_chunk):
 
     return  n
 
-'''# can remove this function - should go into gee_interface
-def construct_region_string(point, size=0.1):
-    """
-    convert a list of two floats [long, lat]
-    into a string representation of four sets of [long,lat]
-    Assume our point is at the centre.
-    """
-    left = point[0] - size/2
-    right = point[0] + size/2
-    top = point[1] + size/2
-    bottom = point[1] - size/2
-    coords =  str([[left,top],[right,top],[right,bottom],[left,bottom]])
-    return coords
-'''
 
 def construct_image_savepath(output_dir, collection_name, coords, date_range, image_type):
     """
@@ -163,108 +149,6 @@ def write_fullsize_images(tif_filebase, output_dir, output_prefix, output_suffix
         bw_ndvi = process_and_threshold(ndvi_image) # new adaptive threshold
         output_filename = construct_filename("ndvibw")
         save_image(bw_ndvi, output_dir, output_filename)
-    
-    # output the full-size black-and-white image
-    #bw_image = convert_to_bw(merged_image, threshold)
-    #output_filename = construct_filename("bw")
-    #save_image(bw_image, output_dir, output_filename)
-
-'''
-def process_coords(coords,
-                   image_coll,
-                   bands,
-                   region_size, ## dimensions of output image in longitude/latitude
-                   scale, # size of each pixel in output image (in m)
-                   start_date,
-                   end_date,
-                   mask_cloud=False, ## EXPERIMENTAL - false by default
-                   output_dir=".",
-                   output_prefix='',
-                   output_suffix=".png",
-                   network_centrality=False,
-                   sub_image_size=[50,50],
-                   threshold=470):
-    """
-    Run through the whole process for one set of coordinates (either a point
-    or a rectangle).
-    """
-    region = construct_region_string(coords, region_size)
-    # Get download URL for all images at these coords
-    download_urls = get_download_urls(coords,
-                                      region,
-                                      image_coll,
-                                      bands,
-                                      scale,
-                                      start_date,
-                                      end_date,
-                                      mask_cloud)
-
-    # loop through these URLS, download zip files, and combine tif files
-    # for each band into RGB output images.
-    for i, url in enumerate(download_urls):
-
-        # construct a temp directory name based on coords and index
-        # of this url in the list
-        tmpdir = os.path.join(TMPDIR, "gee_"+str(coords[0])+"_"\
-                              +str(coords[1])+"_"+str(i))
-        tif_filebases = download_and_unzip(url,tmpdir)
-        if not tif_filebases:
-            continue
-        
-        # Now should have lots of .tif files in a temp dir - merge them
-        # into RGB image files in our chosen output directory
-        for tif_filebase in tif_filebases:
-            
-            merged_image = convert_to_rgb(tif_filebase, bands)
-            ndvi_image = scale_tif(tif_filebase, "NDVI")
-
-            img_array = pillow_to_numpy(merged_image)
-            black = [0,0,0]
-            black_pix_threshold = 0.1
-            n_black_pix = np.count_nonzero(np.all(img_array == black, axis=2))
-
-            if n_black_pix / (img_array.shape[0]*img_array.shape[1]) > black_pix_threshold:
-                print('Detected a low quality image, skipping to next date.')
-                continue
-
-            write_fullsize_images(tif_filebase, output_dir, output_prefix, output_suffix,
-                                  coords, bands, threshold)
-
-            # if requested, divide into smaller sub-images
-            if network_centrality:
-                sub_images = crop_image_npix(ndvi_image,
-                                                sub_image_size[0],
-                                                sub_image_size[1],
-                                                region_size,
-                                                coords
-                )
-
-                # loop through sub images
-                for n, image in enumerate(sub_images):
-                    #sub_image = convert_to_bw(image[0], threshold) # old harccoded threshold
-                    sub_image = process_image(image[0]) # new adaptive threshold
-
-                    sub_coords = image[1]
-                    output_filename = os.path.basename(tif_filebase)
-                    output_filename += "_{0:.3f}_{1:.3f}".format(sub_coords[0], sub_coords[1])
-                    output_filename += '_' + output_suffix
-
-                    # save sub image
-                    save_image(sub_image, output_dir, output_filename)
-
-                    # run network centrality
-                    image_array = pillow_to_numpy(sub_image)
-                    feature_vec, sel_pixels = subgraph_centrality(image_array)
-                    feature_vec_metrics = feature_vector_metrics(feature_vec)
-                    feature_vec_metrics['latitude'] = sub_coords[0]
-                    feature_vec_metrics['longitude'] = sub_coords[1]
-                    feature_vec_metrics['date']= output_prefix
-                    output_filename = os.path.basename(tif_filebase)
-                    output_filename += "_{0:.3f}_{1:.3f}".format(sub_coords[0], sub_coords[1])
-                    output_filename += "_{}".format(output_prefix)
-                    output_filename += '.json'
-                    save_json(feature_vec_metrics, output_dir, output_filename)
-'''
 
 
 def run_network_centrality(output_dir, image, coords, date_range, region_size, sub_image_size=[50,50]):
@@ -435,53 +319,6 @@ def get_weather(output_dir, collection_dict, coords, date_range, region_size=0.1
 
     print (metrics_dict)
     return metrics_dict
-
-
-
-
-''' # will be replaced
-def get_time_series(num_time_periods,
-                    coords, # could be None if we have an input_file listing coords
-                    image_coll,
-                    bands,
-                    region_size, ## dimensions of output image in longitude/latitude
-                    scale, # size of each pixel in output image (in m)
-                    start_date,
-                    end_date,
-                    mask_cloud=False, ## EXPERIMENTAL - false by default
-                    output_dir=".",
-                    output_suffix=".png", # end of output filename, including file extension
-                    network_centrality = False,
-                    sub_image_size=[50,50],
-                    threshold=470):
-    """
-    Divide the time between start_date and end_date into num_time_periods periods
-    and call download_images.process coords for each.
-    """
-    time_periods = divide_time_period(start_date, end_date, num_time_periods)
-    
-    for period in time_periods:
-        print(f"\nProcessing the time period between {period[0]} and {period[1]}...")
-        mid_period_string = find_mid_period(period[0], period[1])
-        output_prefix = mid_period_string
-
-        process_coords(coords,
-                       image_coll,
-                       bands,
-                       region_size,
-                       scale,
-                       period[0],
-                       period[1],
-                       mask_cloud,
-                       output_dir,
-                       output_prefix,
-                       output_suffix,
-                       network_centrality,
-                       threshold=threshold)
-
-        print(f"Finihsed processing the time period between {period[0]} and {period[1]}.")
-    return True
-'''
 
 
 def process_single_collection(output_dir, collection_dict, coords, date_range, n_days_per_slice, region_size=0.1, scale=10):

--- a/pyveg/tests/test_data_extraction.py
+++ b/pyveg/tests/test_data_extraction.py
@@ -41,8 +41,9 @@ data_collections = {
 }
 
 def test_get_vegetation():
-    result = get_vegetation(data_collections['Copernicus'], coordinates, date_range)
-    assert(isinstance(result, float))
+    print('Warning: this test is expected to take a while to run...')
+    nc_results = get_vegetation(data_collections['Copernicus'], coordinates, date_range)
+    assert( len(nc_results) != 0 )
 
 
 def test_get_rainfall():

--- a/pyveg/tests/test_data_extraction.py
+++ b/pyveg/tests/test_data_extraction.py
@@ -1,8 +1,15 @@
+import shutil
+import sys
+
 from pyveg.src.satellite_data_analysis import get_vegetation, get_weather
 
 coordinates = (27.99,11.29)
-date_range = ('2016-01-01', '2017-01-01')
+
+# get one data point for the test
+date_range = ('2016-01-01', '2016-01-31')
 num_days_per_point = 30
+
+do_network_centrality = True
 
 data_collections = {
     'Copernicus' : {
@@ -10,16 +17,16 @@ data_collections = {
         'type': 'vegetation',
         'RGB_bands': ('B4','B3','B2'),
         'NIR_band': 'B8',
-        'cloudy_pix_flag': 'CLOUDY_PIXEL_PERCENTAGE'
+        'cloudy_pix_flag': 'CLOUDY_PIXEL_PERCENTAGE',
+        'do_network_centrality': do_network_centrality
     },
     'Landsat' : {
         'collection_name': 'LANDSAT/LC08/C01/T1_SR',
         'type': 'vegetation',
         'RGB_bands': ('B4','B3','B2'),
-
-
         'NIR_band': 'B5',
-        'cloudy_pix_flag': 'CLOUD_COVER'
+        'cloudy_pix_flag': 'CLOUD_COVER',
+        'do_network_centrality': do_network_centrality
     },
     'NOAA' : {
         'collection_name': 'NOAA/PERSIANN-CDR',
@@ -30,7 +37,6 @@ data_collections = {
         'collection_name': 'NASA/GPM_L3/IMERG_V06',
         'type': 'weather',
         'precipitation_band': ['precipitationCal'],
-        'temperature_band': ['probabilityLiquidPrecipitation']
     },
     'unsupported' : {
         'collection_name': "ECMWF/ERA5/DAILY",
@@ -40,15 +46,17 @@ data_collections = {
     }
 }
 
+test_out_dir = 'test_out'
+
 def test_get_vegetation():
     print('Warning: this test is expected to take a while to run...')
-    nc_results = get_vegetation(data_collections['Copernicus'], coordinates, date_range)
+    nc_results = get_vegetation(test_out_dir, data_collections['Copernicus'], coordinates, date_range, n_sub_images=1)
     assert( len(nc_results) != 0 )
+    shutil.rmtree(test_out_dir, ignore_errors=True)
 
 
 def test_get_rainfall():
-
-    result = get_weather('test',data_collections['NOAA'], coordinates, date_range)
-
+    print('Warning: this test is expected to take a while to run...')
+    result = get_weather(test_out_dir, data_collections['NOAA'], coordinates, date_range)
     assert (len(result.items())!=0)
-
+    shutil.rmtree(test_out_dir, ignore_errors=True)


### PR DESCRIPTION
#79
- Improve entry script to get all options from config by default, and to overwrite from CLI if available. Can now run the script just using `python analyse_gee_data.py`
- Store all outputs under `output/` dir
- Timestamp each output folder
- Organise output folder structure more sensibly (all info by satellite)
- Write out bw ndvi images
- Perform image processing on full sized image
- Move image quality check to it's own function in `image_utils`
- Write all network centrality results to the same json file `network_centralities.json`
- removed unused code