### PR TITLE
use multiprocessing pool to parallelize network centrality calculation

### DIFF
--- a/pyveg/src/data_analysis_utils.py
+++ b/pyveg/src/data_analysis_utils.py
@@ -1,5 +1,5 @@
 """
-Data analysis code including functions to read the .json results file, 
+Data analysis code including functions to read the .json results file,
 and functions analyse and plot the data.
 """
 
@@ -73,9 +73,11 @@ def read_json_to_dataframe(filename):
             # check we have data for this time point
             if time_point is None:
                 continue
-
+            # backwards compatibility, accept either list or dict
+            if isinstance(time_point, dict):
+                time_point = time_point.values()
             # for each space point
-            for space_point in time_point.values():
+            for space_point in time_point:
 
                 # get coordinates
                 date = space_point['date']
@@ -366,9 +368,9 @@ def smooth_subimage(df, column='offset50', n=4, it=3):
         The time-series DataFrame with a new column containing the
         smoothed results.
     """
-    
+
     # add a new column of datetime objects
-    df['datetime'] = pd.to_datetime(df['date'], format='%Y/%m/%d') 
+    df['datetime'] = pd.to_datetime(df['date'], format='%Y/%m/%d')
 
     # extract data
     xs = df['datetime']
@@ -382,7 +384,7 @@ def smooth_subimage(df, column='offset50', n=4, it=3):
 
     # add to df
     df[column+'_smooth'] = smoothed_y
-    
+
     return df
 
 
@@ -394,7 +396,7 @@ def smooth_all_sub_images(df, column='offset50', n=4, it=3):
     Parameters
     ----------
     df : DataFrame
-        DataFrame containing time series results for all sub-images, 
+        DataFrame containing time series results for all sub-images,
         with multiple rows per time point and (lat,long) point.
     column : string, optional
         Name of the column in df to smooth.
@@ -409,7 +411,7 @@ def smooth_all_sub_images(df, column='offset50', n=4, it=3):
     Returns
     ----------
     Dataframe
-        DataFrame of results with a new column containing a 
+        DataFrame of results with a new column containing a
         LOESS smoothed version of the column `column`.
     """
 
@@ -428,7 +430,7 @@ def smooth_all_sub_images(df, column='offset50', n=4, it=3):
     df = list(d.values())[0]
     for df_ in list(d.values())[1:]:
         df = df.append(df_)
-        
+
     return df
 
 def calculate_ci(data, ci_level=0.99):
@@ -449,7 +451,7 @@ def calculate_ci(data, ci_level=0.99):
         where mu is the mean.
 
     """
-    
+
     # remove NaNs
     ys = data.dropna().values
 
@@ -457,13 +459,13 @@ def calculate_ci(data, ci_level=0.99):
     n = len(ys)
     std_err = sem(ys)
     h = std_err * t.ppf((1 + ci_level) / 2, n - 1)
-    
+
     return h
 
 
 def get_confidence_intervals(df, column, ci_level=0.99):
     """
-    Calculate the confidence interval at each time point of a 
+    Calculate the confidence interval at each time point of a
     DataFrame containing data for a large image.
 
     Parameters
@@ -481,16 +483,16 @@ def get_confidence_intervals(df, column, ci_level=0.99):
         Time series data for multiple sub-image locations with
         added column for the ci.
     """
-    
+
     # group all the data at each date
     d = {}
     for name, group in df.groupby(['date']):
         d[name] = group
-    
+
     # for each timepoint, calculate the CI
     for df in d.values():
         df['ci'] = calculate_ci(df[column], ci_level=ci_level)
-    
+
     # merge results
     df = list(d.values())[0]
     for df_ in list(d.values())[1:]:
@@ -501,7 +503,7 @@ def get_confidence_intervals(df, column, ci_level=0.99):
 
 def drop_veg_outliers(dfs, column='offset50', sigmas=3.0):
     """
-    Loop over vegetation DataFrames and drop points in the 
+    Loop over vegetation DataFrames and drop points in the
     time series that a significantly far away from the mean
     of the time series. Such points are assumed to be unphysical.
 
@@ -512,19 +514,19 @@ def drop_veg_outliers(dfs, column='offset50', sigmas=3.0):
     column : str
         Name of the column to drop outliers on.
     sigmas : float
-        Number of standard deviations a data point has to be 
+        Number of standard deviations a data point has to be
         from the mean to be labelled as an outlier and dropped.
 
     Returns
     ----------
     dict of DataFrame
-        Time series data for multiple sub-image locations with 
+        Time series data for multiple sub-image locations with
         some values in `column` potentially set to NaN.
     """
 
-    # set to None data points that are far from the mean, these are 
+    # set to None data points that are far from the mean, these are
     # assumed to be unphysical
-    
+
     # loop over collections
     for col_name, df in dfs.items():
 
@@ -559,7 +561,7 @@ def smooth_veg_data(dfs, column='offset50', n=4):
     Returns
     ----------
     dict of DataFrame
-        Time series data for multiple sub-image locations with 
+        Time series data for multiple sub-image locations with
         new column for smoothed data and ci.
     """
 
@@ -816,12 +818,12 @@ def get_AR1_parameter_estimate(ys):
     float
         The parameter value of the AR(1) model..
     """
-    
+
     if len(ys) < 5:
         return np.NaN
 
     from statsmodels.tsa.ar_model import AutoReg
-    
+
     # more sophisticated models to consider:
     #from statsmodels.tsa.statespace.sarimax import SARIMAX
     #from statsmodels.tsa.arima_model import ARMA
@@ -831,7 +833,7 @@ def get_AR1_parameter_estimate(ys):
 
     # fit
     model = model.fit()
-    
+
     # get the single parameter value
     parameter = model.params[1]
 
@@ -841,9 +843,9 @@ def get_AR1_parameter_estimate(ys):
 def get_kendell_tau(ys):
     """
     Kendall's tau gives information about the trend of the time series.
-    It is just a rank correlation test with one variable being time 
-    (or the vector 1 to the length of the time series), and the other 
-    variable being the data itself. A tau value of 1 means that the 
+    It is just a rank correlation test with one variable being time
+    (or the vector 1 to the length of the time series), and the other
+    variable being the data itself. A tau value of 1 means that the
     time series is always increasing, whereas -1 mean always decreasing,
     and 0 signifies no overall trend.
 

--- a/pyveg/src/process_satellite_data.py
+++ b/pyveg/src/process_satellite_data.py
@@ -9,6 +9,8 @@ import json
 import numpy as np
 import cv2 as cv
 
+from multiprocessing import Pool
+
 from .gee_interface import ee_download
 
 from .image_utils import (
@@ -26,7 +28,6 @@ from .subgraph_centrality import (
     subgraph_centrality,
     feature_vector_metrics,
 )
-
 
 def find_mid_period(start_time, end_time):
     """
@@ -107,7 +108,64 @@ def construct_image_savepath(output_dir, collection_name, coords, date_range, im
     return full_path
 
 
-def run_network_centrality(output_dir, image, coords, date_range, region_size, sub_image_size=[50,50], n_sub_images=-1):
+def process_sub_image(i, sub, output_subdir, date):
+    """
+    function to be used by multiprocessing Pool, called for every sub-image.
+
+    Arguments
+    ---------
+    i : int
+       index of the sub-image
+    sub: (Pillow.Image, (float,float))
+       tuple containing the sub-image, and a tuple of long,lat coords.
+    output_subdir: str
+       subdirectory into which sub-image png files will be saved.
+
+    Returns
+    -------
+    nc_results: list of dictionaries
+               list of length n_sub_images with each entry containing a
+               dictionary with coordinates, dates, feature_vec.
+    """
+    # sub will be a tuple (image, coords) - unpack it here
+    sub_image, sub_coords = sub
+
+    # save sub image
+    output_filename = f'sub{i}_'
+    output_filename += "{0:.3f}-{1:.3f}".format(sub_coords[0], sub_coords[1])
+    output_filename += '.png'
+    save_image(sub_image, output_subdir, output_filename)
+
+    # run network centrality
+    image_array = pillow_to_numpy(sub_image)
+    feature_vec, _ = subgraph_centrality(image_array)
+    nc_result = feature_vector_metrics(feature_vec)
+
+    nc_result['latitude'] = round(sub_coords[0], 4)
+    nc_result['longitude'] = round(sub_coords[1], 4)
+    nc_result['date'] = date
+    nc_result['feature_vec'] = list(feature_vec)
+
+    # write json file for just this sub-image to a temporary location
+    # (to be thread safe, only combine when all parallel jobs are done)
+
+    save_json(nc_result, os.path.join(output_subdir,"tmp_json"), f"network_centrality_sub{i}.json")
+
+
+def consolidate_subimage_json(output_subdir):
+    """
+    Load all the json files from individual sub-images, and return
+    a list of dictionaries, to be written out into one json file.
+    """
+    nc_results = []
+    tmp_json_dir = os.path.join(output_subdir,"tmp_json")
+    for filename in os.listdir(tmp_json_dir):
+        nc_results.append(json.load(open(os.path.join(tmp_json_dir,filename))))
+    save_json(nc_results, output_subdir, "network_centralities.json")
+    return nc_results
+
+
+def run_network_centrality(output_dir, image, coords, date_range, region_size, sub_image_size=[50,50], n_sub_images=-1, n_threads=4):
     """
     !! SVS: Suggest that this function should be moved to the subgraph_centrality.py module
 
@@ -124,15 +182,18 @@ def run_network_centrality(output_dir, image, coords, date_range, region_size, s
         Coordinates of the `image` argument. Used to calcualte
         coordinates of sub-images which are used to ID them.
     date_range : tuple of str
-        (Start date, end data) for filenames. Date strings 
+        (Start date, end data) for filenames. Date strings
         must be formatted as 'YYYY-MM-DD'.
     sub_image_size : list, optional
         Defines the size of the sub-images which network
         centrality will be run on.
     n_sub_images : int, optional
-        The nubmer of sub-images to process. This is useful for 
+        The nubmer of sub-images to process. This is useful for
         testing and speeding up computation. Default is -1 which
         means process the entirety of the larger image.
+    n_threads: int, optional
+        The number of threads to use for parallel processing of sub-images.
+        Default is 4.
 
     Returns
     ----------
@@ -152,44 +213,17 @@ def run_network_centrality(output_dir, image, coords, date_range, region_size, s
                                  region_size,
                                  coords)
 
-    # store results
-    nc_results = {}
-    save_json(nc_results, output_subdir, 'network_centralities.json')
-
-    # loop through sub images
-    for i, (sub_image, sub_coords) in enumerate(sub_images): # possible to parallelise?
-        
-        # if we already got enough results, return early
-        if i >= n_sub_images and n_sub_images != -1:
-            return nc_results
-
-        # save sub image
-        output_filename = f'sub{i}_'
-        output_filename += "{0:.3f}-{1:.3f}".format(sub_coords[0], sub_coords[1])
-        output_filename += '.png'
-        save_image(sub_image, output_subdir, output_filename)
-
-        # run network centrality
-        image_array = pillow_to_numpy(sub_image)
-        feature_vec, _ = subgraph_centrality(image_array)
-        nc_result = feature_vector_metrics(feature_vec)
-        
-        nc_result['latitude'] = round(sub_coords[0], 4)
-        nc_result['longitude'] = round(sub_coords[1], 4)
-        nc_result['date'] = date_range_midpoint
-        nc_result['feature_vec'] = list(feature_vec)
-        
-        # incrementally write json file so we don't have to wait
-        # for the full image to be processed before getting results
-        with open(os.path.join(output_subdir, 'network_centralities.json')) as json_file:
-            nc_results = json.load(json_file)
-            
-            # keep track of the result for this sub-image
-            nc_results[i] = nc_result
-
-            # update json output
-            save_json(nc_results, output_subdir, 'network_centralities.json')
-
+    # if requested to only look at a subset of sub-images, truncate the list here
+    if n_sub_images != -1:
+        sub_images = sub_images[:n_sub_images]
+    # create a multiprocessing pool to handle each sub-image in parallel
+    with Pool(processes=n_threads) as pool:
+        # prepare the arguments for the process_sub_image function
+        arguments=[(i, sub, output_subdir, date_range_midpoint) \
+                   for i,sub in enumerate(sub_images)]
+        pool.starmap(process_sub_image, arguments)
+    # re-combine the results from all sub-images
+    nc_results = consolidate_subimage_json(output_subdir)
     return nc_results
 
 
@@ -203,19 +237,19 @@ def get_vegetation(output_dir, collection_dict, coords, date_range, region_size=
     output_dir : str
         Where to save output images and network centrality results
     collection_dict : dict
-        Dictionary containing information about the collection (name, 
+        Dictionary containing information about the collection (name,
         type, bands, etc). Follows structure in the config file.
     coords : tuple of float
         (Latitude, longitude) coordinates.
     date_range : tuple of str
-        (Start date, end data) for data filtering. Date strings 
+        (Start date, end data) for data filtering. Date strings
         must be formatted as 'YYYY-MM-DD'.
     region_size : float, optional
         Size of the output image (default is 0.1, or 1km).
     scale : int, optional
         Size of each pixel in meters (default 10).
     n_sub_images : int, optional
-        The nubmer of sub-images to process. This is useful for 
+        The nubmer of sub-images to process. This is useful for
         testing and speeding up computation. Default is -1 which
         means process the entirety of the larger image.
 
@@ -234,7 +268,7 @@ def get_vegetation(output_dir, collection_dict, coords, date_range, region_size=
     if len(filenames) == 0:
         with open(os.path.join(output_dir, 'download.log'), 'a+') as file:
             file.write(f'daterange={date_range} coords={coords} >>> {log_msg}\n')
-        return 
+        return
 
     # extract this to feed into `convert_to_rgb()`
     tif_filebase = os.path.join(download_path, filenames[0].split('.')[0])
@@ -245,7 +279,7 @@ def get_vegetation(output_dir, collection_dict, coords, date_range, region_size=
     # check image quality on the colour image
     if not check_image_ok(rgb_image):
         print('Detected a low quality image, skipping to next date.')
-        
+
         with open(os.path.join(output_dir, 'download.log'), 'a+') as file:
             frac = [s for s in log_msg.split(' ') if '/' in s][0]
             file.write(f'daterange={date_range} coords={coords} >>> WARN >>> check_image_ok failed after finding {frac} valid images\n')
@@ -321,7 +355,7 @@ def process_single_collection(output_dir, collection_dict, coords, date_ranges, 
     for date_range in date_ranges:
 
         print(f'Looking for data in the date range {date_range}...')
-        
+
         # process the collection
         if collection_dict['type'] == 'vegetation':
             result = get_vegetation(output_subdir, collection_dict, coords, date_range, region_size, scale)
@@ -331,7 +365,7 @@ def process_single_collection(output_dir, collection_dict, coords, date_ranges, 
         results['time-series-data'][find_mid_period(date_range[0], date_range[1])] = result
 
     print(f'''Finished processing collection "{collection_dict['collection_name']}".''')
-    
+
     return results
 
 


### PR DESCRIPTION
In `process_satellite_data.py` use multiprocessing.Pool to parallelize the calculation of network centrality over the sub-images of a big image.
The `process_sub_image` function is mapped onto the processes, and it writes out a json file to the `tmp_json` subdirectory for just that sub-image.  Once all the sub-images are processed, the `consolidate_subimage_json` function is called to write the `network_centralities.json` file.   This is done rather than having the processes incrementally write to the main json file, in order to be more thread safe.