### PR TITLE
Version control coordaintes

### DIFF
--- a/pyveg/config.py
+++ b/pyveg/config.py
@@ -1,30 +1,42 @@
 #!/usr/bin/env python
 
-#Define directory to save all outputs
+"""
+Configuration file to set parameters for GEE download jobs. This file is 
+used to define job options when running the `pyveg_gee_download` command.
+
+"""
+
+from pyveg.coordinates import coordinate_store
+
+# user specified output dir
 output_dir = 'X'
 
-#coordinates = (23.54,11.34) # beautiful rivers
-#coordinates = (27.99,11.29) # dense spots with river
-#coordinates = (28.37,11.12) # labyrinths
-# coordinates = (28.198,10.96) # gaps
-coordinates = (27.94,11.58) # spots
+# modify this line to set coords based on entries in `coordinates.py`
+coordinate_id = '00'
+
+# parse selection. Note (long, lat) GEE convention.
+entry = coordinate_store.loc[coordinate_id]
+coordinates = (entry.longitude, entry.latitude)
+
+# if you want to test new coordinates without adding them to the store
+# you may overwrite the coordinates here. Note the (long, lat) GEE convention.
+#coordinates = (long, lat)
 
 # date range for Copernicus
-date_range = ('2015-01-01', '2020-01-01')
+date_range = ('2015-01-01', '2020-04-01')
 
-#date range for landsat 5
-#date_range = ('1988-01-01', '2003-01-01')
-
-
-# collections for Copernicus
+# collections for Sentinel2
 collections_to_use = ['Sentinel2', 'ERA5']
 
+# date range for landsat 4/5. In this range there is relatively good data
+#date_range = ('1988-01-01', '2003-01-01')
 # collections to use for old Landsat
 #collections_to_use = ['Landsat4','Landsat5']
 
+# turn off to quickly scout out new locations
+do_network_centrality = False
 
-do_network_centrality = True
-
+# parameter dictionary for different GEE collections
 data_collections = {
     'Sentinel2' : {
         'collection_name': 'COPERNICUS/S2',
@@ -71,4 +83,5 @@ data_collections = {
     }
 }
 
+# select only those collections we want to use in this job
 data_collections = {key : value for key,value in data_collections.items() if key in collections_to_use}

--- a/pyveg/coordinates.py
+++ b/pyveg/coordinates.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+"""
+Store all coordaintes in one place.
+
+In future could think about keeping a record when we run a donwload with 
+the date of download and a commit hash. 
+
+"""
+
+import pandas as pd
+
+# initialise a DataFrame to store coordinates
+coordinates = pd.DataFrame(columns=['continent', 'country', 'type', 'latitude', 'longitude'])
+
+# sudan
+coordinates.append({'continent': 'Africa', 'country': 'Sudan', 'type': 'spots',      'latitude': 11.58, 'longitude': 27.94})
+coordinates.append({'continent': 'Africa', 'country': 'Sudan', 'type': 'labyrinths', 'latitude': 11.12, 'longitude': 28.37})
+coordinates.append({'continent': 'Africa', 'country': 'Sudan', 'type': 'gaps',       'latitude': 10.96, 'longitude': 28.20})
+
+# niger
+coordinates.append({'continent': 'Africa', 'country': 'Niger', 'type': 'tiger bush', 'latitude': 13.12, 'longitude': 2.59})
+coordinates.append({'continent': 'Africa', 'country': 'Niger', 'type': 'tiger bush', 'latitude': 13.17, 'longitude': 1.58})
+
+# senegal
+coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'labyrinths', 'latitude': 15.20, 'longitude': -15.20})
+coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'labyrinths', 'latitude': 15.09, 'longitude': -15.04})
+coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'gaps',       'latitude': 15.80, 'longitude': -14.36})
+coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'gaps',       'latitude': 15.11, 'longitude': -14.53})
+
+# zambia
+coordinates.append({'continent': 'Africa', 'country': 'Zambia', 'type': 'gaps', 'latitude': -15.34, 'longitude': 22.22})
+
+# kenya
+coordinates.append({'continent': 'Africa', 'country': 'Kenya', 'type': 'spots', 'latitude': 0.43, 'longitude': 40.30})
+
+# somalia
+coordinates.append({'continent': 'Africa', 'country': 'Somalia', 'type': 'labyrinths', 'latitude': 8.09, 'longitude': 47.44})
+
+# australia
+coordinates.append({'continent': 'Australia', 'country': 'Australia', 'type': 'gaps', 'latitude': -15.71, 'longitude': 133.10})
+
+# usa
+coordinates.append({'continent': 'America', 'country': 'USA', 'type': 'tiger bush', 'latitude': 26.82, 'longitude': -112.86})
+coordinates.append({'continent': 'America', 'country': 'USA', 'type': 'labyrinths', 'latitude': 31.05, 'longitude': -103.09})

--- a/pyveg/coordinates.py
+++ b/pyveg/coordinates.py
@@ -3,43 +3,59 @@
 """
 Store all coordaintes in one place.
 
-In future could think about keeping a record when we run a donwload with 
-the date of download and a commit hash. 
+To chose a location for download, copy the location id into the relevant
+line in `config.py`
+
+In future think about: 
+ - keeping a record when we run a donwload with the date of download
+   and a commit hash.
+ - having an interface to the `config.py` file which allows the user 
+   to specify groups of coordinates to download in series/parallel.
+   e.g. user specifies that they want to download all "spots" 
+   locations in Africa.
 
 """
 
 import pandas as pd
 
-# initialise a DataFrame to store coordinates
-coordinates = pd.DataFrame(columns=['continent', 'country', 'type', 'latitude', 'longitude'])
+# initialise a DataFrame to store coordinate
+coordinate_store = pd.DataFrame(columns=['continent', 'country', 'type', 'latitude', 'longitude'])
 
+# rename index
+coordinate_store.index.names = ['id']
+
+# --------------------------------------------------------------------------------
 # sudan
-coordinates.append({'continent': 'Africa', 'country': 'Sudan', 'type': 'spots',      'latitude': 11.58, 'longitude': 27.94})
-coordinates.append({'continent': 'Africa', 'country': 'Sudan', 'type': 'labyrinths', 'latitude': 11.12, 'longitude': 28.37})
-coordinates.append({'continent': 'Africa', 'country': 'Sudan', 'type': 'gaps',       'latitude': 10.96, 'longitude': 28.20})
+coordinate_store.loc['00'] = {'continent': 'Africa', 'country': 'Sudan', 'type': 'spots',      'latitude': 11.58, 'longitude': 27.94}
+coordinate_store.loc['01'] = {'continent': 'Africa', 'country': 'Sudan', 'type': 'labyrinths', 'latitude': 11.12, 'longitude': 28.37}
+coordinate_store.loc['02'] = {'continent': 'Africa', 'country': 'Sudan', 'type': 'gaps',       'latitude': 10.96, 'longitude': 28.20}
 
 # niger
-coordinates.append({'continent': 'Africa', 'country': 'Niger', 'type': 'tiger bush', 'latitude': 13.12, 'longitude': 2.59})
-coordinates.append({'continent': 'Africa', 'country': 'Niger', 'type': 'tiger bush', 'latitude': 13.17, 'longitude': 1.58})
+coordinate_store.loc['03'] = {'continent': 'Africa', 'country': 'Niger', 'type': 'tiger bush', 'latitude': 13.12, 'longitude': 2.59}
+coordinate_store.loc['04'] = {'continent': 'Africa', 'country': 'Niger', 'type': 'tiger bush', 'latitude': 13.17, 'longitude': 1.58}
 
 # senegal
-coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'labyrinths', 'latitude': 15.20, 'longitude': -15.20})
-coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'labyrinths', 'latitude': 15.09, 'longitude': -15.04})
-coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'gaps',       'latitude': 15.80, 'longitude': -14.36})
-coordinates.append({'continent': 'Africa', 'country': 'Senegal', 'type': 'gaps',       'latitude': 15.11, 'longitude': -14.53})
+coordinate_store.loc['05'] = {'continent': 'Africa', 'country': 'Senegal', 'type': 'labyrinths', 'latitude': 15.20, 'longitude': -15.20}
+coordinate_store.loc['06'] = {'continent': 'Africa', 'country': 'Senegal', 'type': 'labyrinths', 'latitude': 15.09, 'longitude': -15.04}
+coordinate_store.loc['07'] = {'continent': 'Africa', 'country': 'Senegal', 'type': 'gaps',       'latitude': 15.80, 'longitude': -14.36}
+coordinate_store.loc['08'] = {'continent': 'Africa', 'country': 'Senegal', 'type': 'gaps',       'latitude': 15.11, 'longitude': -14.53}
 
 # zambia
-coordinates.append({'continent': 'Africa', 'country': 'Zambia', 'type': 'gaps', 'latitude': -15.34, 'longitude': 22.22})
+coordinate_store.loc['09'] = {'continent': 'Africa', 'country': 'Zambia', 'type': 'gaps', 'latitude': -15.34, 'longitude': 22.22}
 
 # kenya
-coordinates.append({'continent': 'Africa', 'country': 'Kenya', 'type': 'spots', 'latitude': 0.43, 'longitude': 40.30})
+coordinate_store.loc['10'] = {'continent': 'Africa', 'country': 'Kenya', 'type': 'spots', 'latitude': 0.43, 'longitude': 40.30}
 
 # somalia
-coordinates.append({'continent': 'Africa', 'country': 'Somalia', 'type': 'labyrinths', 'latitude': 8.09, 'longitude': 47.44})
+coordinate_store.loc['11'] = {'continent': 'Africa', 'country': 'Somalia', 'type': 'labyrinths', 'latitude': 8.09, 'longitude': 47.44}
 
 # australia
-coordinates.append({'continent': 'Australia', 'country': 'Australia', 'type': 'gaps', 'latitude': -15.71, 'longitude': 133.10})
+coordinate_store.loc['12'] = {'continent': 'Australia', 'country': 'Australia', 'type': 'gaps', 'latitude': -15.71, 'longitude': 133.10}
 
 # usa
-coordinates.append({'continent': 'America', 'country': 'USA', 'type': 'tiger bush', 'latitude': 26.82, 'longitude': -112.86})
-coordinates.append({'continent': 'America', 'country': 'USA', 'type': 'labyrinths', 'latitude': 31.05, 'longitude': -103.09})
+coordinate_store.loc['13'] = {'continent': 'America', 'country': 'USA', 'type': 'tiger bush', 'latitude': 26.82, 'longitude': -112.86}
+coordinate_store.loc['14'] = {'continent': 'America', 'country': 'USA', 'type': 'labyrinths', 'latitude': 31.05, 'longitude': -103.09}
+# --------------------------------------------------------------------------------
+
+# hardcode a check to make sure we don't overwrite any rows 
+assert( len(coordinate_store) == 15 )

--- a/pyveg/scripts/download_gee_data.py
+++ b/pyveg/scripts/download_gee_data.py
@@ -34,8 +34,10 @@ import argparse
 import warnings
 import time
 from shutil import copyfile
+
 from pyveg.src.process_satellite_data import process_all_collections
 from pyveg import config
+from pyveg.coordinates import coordinate_store
 
 
 def main():
@@ -88,6 +90,25 @@ def main():
     print('-'*35)
     print('Running download_gee_data.py')
     print('-'*35)
+
+    # print job configuration to the user
+    print('Job Configuration:')
+
+    # search coordinate store to see if we have an entry for these coordinates
+    long, lat = config.coordinates
+    entry = coordinate_store[(coordinate_store['longitude'] == long) & (coordinate_store['latitude'] == lat)]
+
+    if entry.empty:
+        print(f'* Warning: running with unknown coordinates: {config.coordinates}.')
+    elif len(entry) == 1:
+        print(f'* Running with location id {entry.index[0]}:')
+        print(entry.to_string(index=False))
+    else:
+        raise RuntimeError('Coordinate store error.')
+    
+    print(f'* date range:\t {config.date_range}')
+    collection_names = [c['collection_name'] for c in config.data_collections.values()]
+    print(f'* collections:\t {collection_names}\n')
 
     # run!
     process_all_collections(config.output_dir,


### PR DESCRIPTION
#208 
- Add `coordinates.py` file containing a DataFrame of known coordinates. Currently contains 15 locations.
- Minor changes to `config.py` for compatability with the coordinate store. User can still specify coordaintes if they choose, or use an ID of a location in the coordinate store. IDs are currently hardcoded in `coordinates.py`.
- Improve output at start of `pyveg_gee_download` command to print job configuration.

I didn't worry too much about hardcoding as I'm hoping we won't modify `coordinates.py` too often.