### PR TITLE
Feature/237 alternative smoothing

### DIFF
--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -136,7 +136,7 @@ def analyse_gee_data(input_dir, spatial):
 
         # run the standard or detrended analysis
         if 'detrended' in filename:
-            output_subdir = os.path.join(output_dir, 'detrended')
+            output_subdir = os.path.join(output_dir, os.path.splitext(filename)[0])
             run_time_series_analysis(os.path.join(ts_dirname, filename), output_subdir, detrended=True)
         else: 
             output_subdir = output_dir

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -113,7 +113,7 @@ def analyse_gee_data(input_dir, spatial):
     """
 
     # preprocess input data
-    ts_dirname, dfs = preprocess_data(input_dir, n_smooth=3)
+    ts_dirname, dfs = preprocess_data(input_dir, n_smooth=4)
 
     # get filenames of preprocessed data time series
     ts_filenames = [f for f in os.listdir(ts_dirname) if 'time_series' in f]

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -411,6 +411,7 @@ def smooth_subimage(df, column='offset50', n=4, it=3):
 
     # add to df
     df[column + '_smooth'] = smoothed_y
+    df[column + '_smooth_res'] = ys - smoothed_y
 
     return df
 
@@ -487,6 +488,13 @@ def detrend_df(df, lag):
     # detrend veg and climate columns
     for col in columns:
         df_out[col] = df_out[col].diff(lag)
+
+    # need to keep this info for smoothing later
+    try:
+        df_out['latitude'] = df['latitude']
+        df_out['longitude'] = df['longitude']
+    except:
+        pass
 
     return df_out
 
@@ -805,12 +813,24 @@ def preprocess_data(input_dir, drop_outliers=True, fill_missing=True,
         # remove seasonality from sub-image time series
         dfs_detrended = detrend_data(dfs, lag=12)
 
+        print('- Smoothing vegetation time series after removing seasonlity...')
+        dfs_detrended_smooth = smooth_veg_data(dfs_detrended.copy(), n=4)
+
         # combine over sub-images
-        ts_df_detrended = make_time_series(dfs_detrended)
+        ts_df_smooth_detrended = make_time_series(dfs_detrended)
+
+        ts_df_detrended_smooth = make_time_series(dfs_detrended_smooth)
+
 
         # save output
         ts_filename_detrended = os.path.join(output_dir, 'time_series_detrended.csv')
         print(f'Saving detrended time series to "{ts_filename_detrended}".')
-        ts_df_detrended.to_csv(ts_filename_detrended, index=False)
-    
+        ts_df_smooth_detrended.to_csv(ts_filename_detrended, index=False)
+
+     # save output
+        ts_filename_detrended = os.path.join(output_dir, 'time_series_detrended_smooth.csv')
+        print(f'Saving detrended time series to "{ts_filename_detrended}".')
+        ts_df_detrended_smooth.to_csv(ts_filename_detrended, index=False)
+
+
     return output_dir, dfs # for now return `dfs` for spatial plot compatibility 

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -711,11 +711,14 @@ def detrend_data(dfs, lag):
             for df_ in list(d.values())[1:]:
                 df = df.append(df_)
 
+            df.dropna(inplace=True)
+
             dfs[col_name] = df
 
         else:
             # remove seasonality for weather data, this is a simpler time series
             dfs[col_name] = detrend_df(dfs[col_name], lag)
+            df.dropna(inplace=True)
 
     return dfs
 
@@ -815,21 +818,14 @@ def preprocess_data(input_dir, drop_outliers=True, fill_missing=True,
         dfs_detrended = detrend_data(dfs, lag=12)
 
         print('- Smoothing vegetation time series after removing seasonlity...')
-        dfs_detrended_smooth = smooth_veg_data(dfs_detrended, n=4)
+        dfs_detrended_smooth = smooth_veg_data(dfs_detrended, n=12)
+
 
         # combine over sub-images
-        ts_df_smooth_detrended = make_time_series(dfs_detrended)
-
         ts_df_detrended_smooth = make_time_series(dfs_detrended_smooth)
-
 
         # save output
         ts_filename_detrended = os.path.join(output_dir, 'time_series_detrended.csv')
-        print(f'Saving detrended time series to "{ts_filename_detrended}".')
-        ts_df_smooth_detrended.to_csv(ts_filename_detrended, index=False)
-
-     # save output
-        ts_filename_detrended = os.path.join(output_dir, 'time_series_detrended_smooth.csv')
         print(f'Saving detrended time series to "{ts_filename_detrended}".')
         ts_df_detrended_smooth.to_csv(ts_filename_detrended, index=False)
 

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -824,7 +824,6 @@ def preprocess_data(input_dir, drop_outliers=True, fill_missing=True,
         print('- Smoothing vegetation time series after removing seasonlity...')
         dfs_detrended_smooth = smooth_veg_data(dfs_detrended, n=12)
 
-
         # combine over sub-images
         ts_df_detrended_smooth = make_time_series(dfs_detrended_smooth)
 
@@ -832,6 +831,5 @@ def preprocess_data(input_dir, drop_outliers=True, fill_missing=True,
         ts_filename_detrended = os.path.join(output_dir, 'time_series_detrended.csv')
         print(f'Saving detrended time series to "{ts_filename_detrended}".')
         ts_df_detrended_smooth.to_csv(ts_filename_detrended, index=False)
-
 
     return output_dir, dfs # for now return `dfs` for spatial plot compatibility 

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -395,6 +395,7 @@ def smooth_subimage(df, column='offset50', n=4, it=3):
         The time-series DataFrame with a new column containing the
         smoothed results.
     """
+    df.dropna(inplace=True)
 
     # add a new column of datetime objects
     df['datetime'] = pd.to_datetime(df['date'], format='%Y/%m/%d')
@@ -814,7 +815,7 @@ def preprocess_data(input_dir, drop_outliers=True, fill_missing=True,
         dfs_detrended = detrend_data(dfs, lag=12)
 
         print('- Smoothing vegetation time series after removing seasonlity...')
-        dfs_detrended_smooth = smooth_veg_data(dfs_detrended.copy(), n=4)
+        dfs_detrended_smooth = smooth_veg_data(dfs_detrended, n=4)
 
         # combine over sub-images
         ts_df_smooth_detrended = make_time_series(dfs_detrended)

--- a/pyveg/src/plotting.py
+++ b/pyveg/src/plotting.py
@@ -556,11 +556,11 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
         ar1 = ar1_df[column.replace('var', 'ar1')]
         ar1_se = ar1_df[column.replace('var', 'ar1_se')]
 
-        if any(['smooth' in c for c in df.columns]):
-            variance_smooth = var_df[column.replace('offset50_mean', 'offset50_smooth_mean')]
-            ar1_smooth = ar1_df[column.replace('var', 'ar1').replace('offset50_mean', 'offset50_smooth_mean')]
-            ar1_se_smooth = ar1_df[column.replace('var', 'ar1_se').replace('offset50_mean', 'offset50_smooth_mean')]
-        
+        if any([filename_suffix in c for c in df.columns]):
+            variance_smooth = var_df[column.replace('offset50_mean', 'offset50_'+filename_suffix+'_mean')]
+            ar1_smooth = ar1_df[column.replace('var', 'ar1').replace('offset50_mean', 'offset50_'+filename_suffix+'_mean')]
+            ar1_se_smooth = ar1_df[column.replace('var', 'ar1_se').replace('offset50_mean', 'offset50_'+filename_suffix+'_mean')]
+
         # create a figure
         fig, ax = plt.subplots(figsize=(15, 5))
         plt.xlabel('Time', fontsize=12)
@@ -575,7 +575,7 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
         ax.fill_between(ar1_xs, ar1 - ar1_se, ar1 + ar1_se,
                         facecolor='blue', alpha=0.1, label='AR1 SE')
 
-        if any(['smooth' in c for c in df.columns]):
+        if any([filename_suffix in c for c in df.columns]):
             # plot smoothed vegetation ar1 and std
             ax.plot(ar1_xs, ar1_smooth, label='AR1 Smoothed', linewidth=2, color='tab:blue', linestyle='dotted')
             ax.fill_between(ar1_xs, ar1_smooth - ar1_se_smooth, ar1_smooth + ar1_se_smooth,
@@ -595,7 +595,7 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
 
         # plot variance
         ax2.plot(var_xs, variance, linewidth=2, color=color, alpha=0.75, label='Variance')
-        if any(['smooth' in c for c in df.columns]):
+        if any([filename_suffix in c for c in df.columns]):
             ax2.plot(var_xs, variance_smooth, linewidth=2, color=color, alpha=0.75, 
                      linestyle='dotted', label='Variance Smoothed')
 
@@ -627,4 +627,5 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
     for column in df.columns:
         if (('offset50_mean' in column or 'total_precipitation' in column) and 
              'var' in column):
-            make_plot(df, column, output_dir, filename_suffix)
+            make_plot(df, column, output_dir, 'smooth')
+            make_plot(df, column, output_dir, 'smooth_res')

--- a/pyveg/src/plotting.py
+++ b/pyveg/src/plotting.py
@@ -529,7 +529,7 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
         Add suffix string to file name
     """
 
-    def make_plot(df, column, output_dir, filename_suffix):
+    def make_plot(df, column, output_dir, smoothing_option):
         """
         Parameters
         ----------
@@ -539,8 +539,8 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
             Column name an offset50 variance column in df.
         output_dir : str
             Directory to save the plot in.
-        filename_suffix: str
-            Add suffix string to file name
+        smoothing_option: str
+            Label for smoothing variable to be used
         """
 
         # get short string prefix on column name
@@ -559,10 +559,10 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
         ar1 = ar1_df[column.replace('var', 'ar1')]
         ar1_se = ar1_df[column.replace('var', 'ar1_se')]
 
-        if any([filename_suffix in c for c in df.columns]):
-            variance_smooth = var_df[column.replace('offset50_mean', 'offset50_'+filename_suffix+'_mean')]
-            ar1_smooth = ar1_df[column.replace('var', 'ar1').replace('offset50_mean', 'offset50_'+filename_suffix+'_mean')]
-            ar1_se_smooth = ar1_df[column.replace('var', 'ar1_se').replace('offset50_mean', 'offset50_'+filename_suffix+'_mean')]
+        if any([smoothing_option in c for c in df.columns]):
+            variance_smooth = var_df[column.replace('offset50_mean', 'offset50_' + smoothing_option + '_mean')]
+            ar1_smooth = ar1_df[column.replace('var', 'ar1').replace('offset50_mean', 'offset50_' + smoothing_option + '_mean')]
+            ar1_se_smooth = ar1_df[column.replace('var', 'ar1_se').replace('offset50_mean', 'offset50_' + smoothing_option + '_mean')]
 
         # create a figure
         fig, ax = plt.subplots(figsize=(15, 5))
@@ -578,7 +578,7 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
         ax.fill_between(ar1_xs, ar1 - ar1_se, ar1 + ar1_se,
                         facecolor='blue', alpha=0.1, label='AR1 SE')
 
-        if any([filename_suffix in c for c in df.columns]):
+        if any([smoothing_option in c for c in df.columns]):
             # plot smoothed vegetation ar1 and std
             ax.plot(ar1_xs, ar1_smooth, label='AR1 Smoothed', linewidth=2, color='tab:blue', linestyle='dotted')
             ax.fill_between(ar1_xs, ar1_smooth - ar1_se_smooth, ar1_smooth + ar1_se_smooth,
@@ -598,7 +598,7 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
 
         # plot variance
         ax2.plot(var_xs, variance, linewidth=2, color=color, alpha=0.75, label='Variance')
-        if any([filename_suffix in c for c in df.columns]):
+        if any([smoothing_option in c for c in df.columns]):
             ax2.plot(var_xs, variance_smooth, linewidth=2, color=color, alpha=0.75, 
                      linestyle='dotted', label='Variance Smoothed')
 
@@ -630,7 +630,7 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=""):
         fig.tight_layout()
 
         # save the plot
-        output_filename = collection_prefix + '-moving-window-AR1-var' + filename_suffix + '.png'
+        output_filename = collection_prefix + '-moving-window-AR1-var' + smoothing_option + '.png'
         print(f'Plotting {collection_prefix} moving window time series...')
         plt.savefig(os.path.join(output_dir, output_filename), dpi=DPI)
 


### PR DESCRIPTION
- [x] Change smoothing function to also return residuals
- [x] Keep lat and long variables in the detrended functions to be able to run smoothing later
- [x] Remove nans before doing smoothing on the smoothing function (this affected the smoothing after the detrending).
- [x] Do smoothing after detrending
- [x] Change AR1 analysis to be done on the detrended smoothed residuals (and also just detrended data) 
- [x] Set up detrended smoothing to a bandwidth of 12.
- [x] Add AR1 and var Kendal Tau on plots for booth smooth and non-smooth residuals
- [x] Make sure time series and autocorrelation plots do smoothed time series and residuals.
