### PR TITLE
Feature/270 update gee version

### DIFF
--- a/pyveg/requirements.txt
+++ b/pyveg/requirements.txt
@@ -9,7 +9,7 @@ requests
 dateparser
 python-igraph
 geopandas
-earthengine-api==0.1.210
+earthengine-api==0.1.222
 geetools
 pillow
 imageio

--- a/pyveg/src/download_modules.py
+++ b/pyveg/src/download_modules.py
@@ -54,9 +54,10 @@ class BaseDownloader(BaseModule):
         Note that these can be overriden by either values held by a parent Sequence
         or by calling configure() with a configuration dictionary.
         """
-
-        self.region_size = 0.1
-        self.scale = 10
+        if not "region_size" in vars(self):
+            self.region_size = 0.08
+        if not "scale" in vars(self):
+            self.scale = 10
         if not "output_dir" in vars(self):
             self.set_output_dir()
         return

--- a/pyveg/src/image_utils.py
+++ b/pyveg/src/image_utils.py
@@ -98,12 +98,12 @@ def combine_tif(input_filebase, bands=["B4", "B3", "B2"]):
     else:
         raise RuntimeError("Need three bands to combine into RGB image")
     for col in band_dict.keys():
-        im = Image.open(input_filebase+"."+band_dict[col]["band"]+".tif")
-        pix = im.load()
+
+        pix = cv.imread(input_filebase+"."+band_dict[col]["band"]+".tif",cv.IMREAD_ANYDEPTH)
         # find the minimum and maximum pixel values in the original scale
         #print("Found image of size {}".format(im.size))
-        for ix in range(im.size[0]):
-            for iy in range(im.size[1]):
+        for ix in range(pix.shape[0]):
+            for iy in range(pix.shape[1]):
                 if pix[ix, iy] > band_dict[col]["max_val"]:
                     band_dict[col]["max_val"] = pix[ix, iy]
                 elif pix[ix, iy] < band_dict[col]["min_val"]:
@@ -122,9 +122,9 @@ def combine_tif(input_filebase, bands=["B4", "B3", "B2"]):
                    #                   band_dict[col]["max_val"]
                    (overall_max+1)
                    ))
-    new_img = Image.new("RGB", im.size)
-    for ix in range(im.size[0]):
-        for iy in range(im.size[1]):
+    new_img = Image.new("RGB", pix.shape)
+    for ix in range(new_img.size[0]):
+        for iy in range(new_img.size[1]):
             new_img.putpixel((ix, iy), tuple(get_pix_val(ix, iy, col)
                                              for col in ["r", "g", "b"]))
     return new_img
@@ -138,12 +138,11 @@ def scale_tif(input_filebase, band):
     max_val = -1*sys.maxsize
     min_val = sys.maxsize
     # load the single band file and extract pixel data
-    im = Image.open(input_filebase+"."+band+".tif")
-    pix = im.load()
+    pix = cv.imread(input_filebase+"."+band+".tif",cv.IMREAD_ANYDEPTH)
     # find the minimum and maximum pixel values in the original scale
     #print("Found image of size {}".format(im.size))
-    for ix in range(im.size[0]):
-        for iy in range(im.size[1]):
+    for ix in range(pix.shape[0]):
+        for iy in range(pix.shape[1]):
             if pix[ix, iy] > max_val:
                 max_val = pix[ix, iy]
             elif pix[ix, iy] < min_val:
@@ -160,9 +159,9 @@ def scale_tif(input_filebase, band):
     def get_pix_val(ix, iy): return \
         int((pix[ix, iy] + 1 ) / 2 * 255)
 
-    new_img = Image.new("RGB", im.size)
-    for ix in range(im.size[0]):
-        for iy in range(im.size[1]):
+    new_img = Image.new("RGB", pix.shape)
+    for ix in range(new_img.size[0]):
+        for iy in range(new_img.size[1]):
             new_img.putpixel((ix, iy), tuple(get_pix_val(ix, iy)
                                              for col in ["r", "g", "b"]))
     return new_img

--- a/pyveg/src/processor_modules.py
+++ b/pyveg/src/processor_modules.py
@@ -56,10 +56,12 @@ class VegetationImageProcessor(ProcessorModule):
         by a parent Sequence, or by calling configure() with a dict of values
         """
         super().set_default_parameters()
-        self.region_size = 0.1
-        self.RGB_bands = ["B4","B3","B2"]
-        self.split_RGB_images = True
-
+        if not "region_size" in vars(self):
+            self.region_size = 0.1
+        if not "RGB_bands" in vars(self):
+            self.RGB_bands = ["B4","B3","B2"]
+        if not "split_RGB_images" in vars(self):
+            self.split_RGB_images = True
 
 
     def construct_image_savepath(self, date_string, coords_string, image_type):


### PR DESCRIPTION
Update to the latest version of the GEE python api: earthengine-api 0.1.222. and fixes for various knock-on effects, i.e.:
* Reduce region_size from 0.1 to 0.08, in order that our downloads do not exceed GEE's size limit.
* Use cv2.imread rather than Image.open to read the tif files into pixel arrays.   For some reason the latter doesn't work with the tif files downloaded using the latest version.