### PR TITLE
Add veg-precip correlation moving window analysis

### DIFF
--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -34,8 +34,8 @@ from pyveg.src.plotting import (
     plot_moving_window_analysis,
     plot_ews_resiliance,
     plot_sensitivity_heatmap,
+    plot_correlation_mwa,
     kendall_tau_histograms
-
 )
 
 
@@ -127,6 +127,7 @@ def run_early_warnings_resilience_analysis(filename, output_dir):
 
     # make plots
     plot_moving_window_analysis(mwa_df, mwa_subdir)
+    plot_correlation_mwa(mwa_df, mwa_subdir)
 
     # save to csv
     mwa_df.to_csv(os.path.join(mwa_subdir, 'moving-window-analysis.csv'), index=False)

--- a/pyveg/src/data_analysis_utils.py
+++ b/pyveg/src/data_analysis_utils.py
@@ -688,13 +688,15 @@ def early_warnings_sensitivity_analysis(series,
                                         incrbandwidth = 0.2,
                                         incrspanrange = 0.1):
 
-    '''
+    """
+    Function to estimate the sensitivity of the early warnings analysis to 
+    the smoothing and windowsize used. The function returns a dataframe that 
+    contains the Kendall tau rank correlation estimates for the rolling window 
+    sizes (winsize variable) and bandwidths or span sizes depending on the 
+    de-trending (smooth variable).
 
-    Function to estimate the sensitivity of the early warnings analysis to the smoothing and windowsize used. The function
-    returns a dataframe that contains the Kendall tau rank correlation estimates for the rolling window sizes (winsize variable)
-    and bandwidths or span sizes depending on the de-trending (smooth variable).
-
-    This function is inspired in the sensitivity_ews.R function from Vasilis Dakos, Leo Lahti in the early-warnings-R package
+    This function is inspired in the sensitivity_ews.R function from Vasilis 
+    Dakos, Leo Lahti in the early-warnings-R package:
     https://github.com/earlywarningtoolbox/earlywarnings-R.
 
     Parameters
@@ -723,9 +725,7 @@ def early_warnings_sensitivity_analysis(series,
     DataFrame:
         A dataframe that contains the Kendall tau rank correlation estimates for the rolling window sizes (winsize variable)
      and bandwidths or span sizes depending on the de-trending (smooth variable).
-
-
-    '''
+    """
 
     results_kendal_tau = []
     for winsize in np.arange(winsizerange[0],winsizerange[1]+0.01,incrwinsize):
@@ -795,12 +795,16 @@ def early_warnings_null_hypothesis(series,
                                    band_width=0.2,
                                    lag_times=[1],
                                    n_simulations=1000):
-    '''
-
-       Function to estimate the significance of the early warnings analysis by performing a null hypothesis test. The function
-    estimate distributions of trends in early warning indicators from different surrogate timeseries generated after fitting an ARMA(p,q) model on the original data.
-     The trends are estimated by the nonparametric Kendall tau correlation coefficient and can be compared to the trends estimated in the original timeseries
-     to produce probabilities of false positives. The function returns a dataframe that contains the Kendall tau rank correlation estimates for orignal data and surrogates.
+    """
+    Function to estimate the significance of the early warnings analysis 
+    by performing a null hypothesis test. The function estimate distributions 
+    of trends in early warning indicators from different surrogate timeseries 
+    generated after fitting an ARMA(p,q) model on the original data.
+    The trends are estimated by the nonparametric Kendall tau correlation 
+    coefficient and can be compared to the trends estimated in the original 
+    timeseries to produce probabilities of false positives. The function 
+    returns a dataframe that contains the Kendall tau rank correlation 
+    estimates for orignal data and surrogates.
 
     Parameters
     ----------
@@ -828,10 +832,10 @@ def early_warnings_null_hypothesis(series,
     Returns
     --------
     DataFrame:
-        A dataframe that contains the Kendall tau rank correlation estimates for each indicator estimated on each surrogate
-        dataset.
+        A dataframe that contains the Kendall tau rank correlation estimates for each 
+        indicator estimated on each surrogate dataset.
 
-    '''
+    """
 
     ews_dic = ewstools.core.ews_compute(series,
                                         roll_window=roll_window,
@@ -865,10 +869,10 @@ def early_warnings_null_hypothesis(series,
                 result = model_fit
 
     def compute_indicators(series):
-
-        ''' Rolling window indicators computation based on the ewstools.core.ews_compute function from
+        """
+        Rolling window indicators computation based on the ewstools.core.ews_compute function from
         ewstools
-        '''
+        """
 
         df_ews = pd.DataFrame()
         # Compute the rolling window size (integer value)

--- a/pyveg/src/data_analysis_utils.py
+++ b/pyveg/src/data_analysis_utils.py
@@ -629,7 +629,7 @@ def get_corrs_by_lag(series_A, series_B):
         # correlate with series_B
         corr = series_B.corr(lagged_data)
         correlations.append(round(corr,4))
-    print(correlations)
+
     return correlations
 
 

--- a/pyveg/src/data_analysis_utils.py
+++ b/pyveg/src/data_analysis_utils.py
@@ -749,7 +749,8 @@ def moving_window_analysis(df, output_dir, window_size=0.5):
         # for the precipitation column, look at correlations to veg
         if 'total_precipitation' in column:
             for column_veg in df.columns:
-                if ('offset50' in column_veg or 'ndvi' in column_veg) and 'mean' in column_veg:
+                if (('offset50' in column_veg or 'ndvi' in column_veg) and 
+                     'mean' in column_veg and 'smooth' not in column_veg):
                     mwa_df = mwa_df.join(get_correlation_lag_ts(df.set_index('date')[column_veg],
                                                                 df.set_index('date')[column]), how='outer')
 

--- a/pyveg/src/data_analysis_utils.py
+++ b/pyveg/src/data_analysis_utils.py
@@ -697,8 +697,9 @@ def get_correlation_lag_ts(series_A, series_B, window_size=0.5):
         mag_max_cors_mw.append(frame_lag_max_cor)
         index.append(series_A_lagged.index[length + i])
 
-    correlations_mva_series_name = series_A.name.split('_')[0] + '_veg_precip_corr'
-    mag_max_cors_mw_series_name = series_A.name.split('_')[0] + '_veg_precip_lag'
+    s = 'ndvi' if 'ndvi' in series_A else 'offest50'
+    correlations_mva_series_name = series_A.name.split('_')[0] + '_' + s + '_precip_corr'
+    mag_max_cors_mw_series_name = series_A.name.split('_')[0] + '_' + s + '_precip_lag'
 
     out_df = pd.DataFrame()
     out_df[correlations_mva_series_name] = pd.Series(correlations_mw)

--- a/pyveg/src/plotting.py
+++ b/pyveg/src/plotting.py
@@ -901,19 +901,18 @@ def plot_sensitivity_heatmap(series_name, df, output_dir):
 
 
 def kendall_tau_histograms(series_name, df, output_dir):
-    '''
+    """
+    Produce histograms with kendall tau distribution from surrogates for significance analysis
 
-      Produce histograms with kendall tau distribution from surrogates for significance analysis
-
-      Parameters
-      ----------
+    Parameters
+    ----------
     series_name : str
         String containing data collection and time series variable.
-      df: Dataframe
+    df: Dataframe
           The output dataframe from the sensitivity analysis function.
-      output_dir:
+    output_dir:
           Path to the directory to save the produced figures
-      '''
+    """
 
     for column in df.columns:
 

--- a/pyveg/src/plotting.py
+++ b/pyveg/src/plotting.py
@@ -743,21 +743,44 @@ def plot_moving_window_analysis(df, output_dir, filename_suffix=''):
 
 
 def plot_correlation_mwa(df, output_dir, filename_suffix=''):
+    """
+    Given a moving window time series DataFrame, plot the time series 
+    of veg-precip correlation.
+
+    Parameters
+    ----------
+    df : DataFrame
+        The time-series results for veg-precip correlation coeff and lag.
+    output_dir : str
+        Directory to save the plot in.
+    filename_suffix: str
+        Add suffix string to file name
+    """
 
     def make_plot(df, column_name, output_dir, filename_suffix):
 
-        collection_prefix = column_name.split('_')[0]
+        # get datetime x-values
+        xs = get_datetime_xs(df)
+        
         # create a figure
-        fig, _ = plt.subplots(figsize=(15, 5))
-        plt.plot(df[column_name])
+        fig, ax = plt.subplots(figsize=(15, 4.5))
+        plt.plot(xs, df[column_name])
+
+        # label axes
+        plt.xlabel('Time', fontsize=12)
+        plt.ylabel(column_name, fontsize=12)
+
+        # calculate Kendall taus and annotate plot
+        tau, p = get_kendell_tau(df[column_name].dropna())
+        textstr = f'Kendall $\\tau,~p = {tau:.3f}$, ${p:.4f}$'
+        ax.text(0.1, 0.95, textstr, transform=ax.transAxes, fontsize=14, verticalalignment='top')
 
         # save the plot
         output_filename = f'{column_name}' + filename_suffix + '.png'
+        collection_prefix = column_name.split('_')[0]
         print(f'Plotting {collection_prefix} correlation moving window analysis...')
         plt.savefig(os.path.join(output_dir, output_filename), dpi=DPI)
         plt.close(fig)
-
-
 
     for column in df.columns:
         if 'veg_precip' in column:

--- a/pyveg/tests/test_data_analysis_utils.py
+++ b/pyveg/tests/test_data_analysis_utils.py
@@ -55,4 +55,4 @@ def test_moving_window_analysis():
     ar1_var_df = moving_window_analysis(time_series_dfs, os.path.dirname(path_to_dict), 0.5)
 
     keys_ar1 = list(ar1_var_df.keys())
-    assert (ar1_var_df.shape == (38, 7))
+    assert (ar1_var_df.shape == (38, 9))


### PR DESCRIPTION
#275 

example plots for (-15.00,15.40):

Seasonal:
![L7_veg_precip_corr](https://user-images.githubusercontent.com/16232199/82905192-757a2180-9f5b-11ea-8c02-628f47cdf9c9.png)
![L7_veg_precip_lag](https://user-images.githubusercontent.com/16232199/82905200-76ab4e80-9f5b-11ea-8204-001d591e9270.png)

Deseasonalised:
![L7_veg_precip_corr](https://user-images.githubusercontent.com/16232199/82905291-98a4d100-9f5b-11ea-8752-c1e8771b08f0.png)
![L7_veg_precip_lag](https://user-images.githubusercontent.com/16232199/82905293-993d6780-9f5b-11ea-8fb7-87c5c11d956d.png)


Clearly something has broken the Kendall tau p-values. Though I haven't figured out what yet...
