### PR TITLE
Feature/293 min max dates for collections

### DIFF
--- a/pyveg/config.py
+++ b/pyveg/config.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+"""
+Configuration file to set parameters for GEE download jobs. This file is 
+used to define job options when running the `pyveg_gee_download` command.
+
+"""
+
+from pyveg.coordinates import coordinate_store
+
+# user specified output dir
+output_dir = 'X'
+
+# modify this line to set coords based on entries in `coordinates.py`
+coordinate_id = '00'
+
+# parse selection. Note (long, lat) GEE convention.
+entry = coordinate_store.loc[coordinate_id]
+coordinates = (entry.longitude, entry.latitude)
+
+# if you want to test new coordinates without adding them to the store
+# you may overwrite the coordinates here. Note the (long, lat) GEE convention.
+#coordinates = (long, lat)
+
+# date range for Copernicus
+date_range = ('2015-01-01', '2020-04-01')
+
+# collections for Sentinel2
+collections_to_use = ['Sentinel2', 'ERA5']
+
+# date range for landsat 4/5. In this range there is relatively good data
+#date_range = ('1988-01-01', '2003-01-01')
+# collections to use for old Landsat
+#collections_to_use = ['Landsat4','Landsat5']
+
+# turn off to quickly scout out new locations
+do_network_centrality = True
+
+# parameter dictionary for different GEE collections
+data_collections = {
+    'Sentinel2' : {
+        'collection_name': 'COPERNICUS/S2',
+        'type': 'vegetation',
+        'RGB_bands': ('B4','B3','B2'),
+        'NIR_band': 'B8',
+        'cloudy_pix_flag': 'CLOUDY_PIXEL_PERCENTAGE',
+        'do_network_centrality': do_network_centrality,
+        'num_days_per_point': 30
+    },
+    'Landsat8' : {
+        'collection_name': 'LANDSAT/LC08/C01/T1_SR',
+        'type': 'vegetation',
+        'RGB_bands': ('B4','B3','B2'),
+        'NIR_band': 'B5',
+        'cloudy_pix_flag': 'CLOUD_COVER',
+        'do_network_centrality': do_network_centrality,
+        'num_days_per_point': 90
+    },
+    'Landsat5' : {
+        'collection_name': 'LANDSAT/LT05/C01/T1_SR',
+        'type': 'vegetation',
+        'RGB_bands': ('B3','B2','B1'),
+        'NIR_band': 'B4',
+        'cloudy_pix_flag': 'None',
+        'do_network_centrality': do_network_centrality,
+        'num_days_per_point': 90
+    },
+    'Landsat4' : {
+        'collection_name': 'LANDSAT/LT04/C01/T1_SR',
+        'type': 'vegetation',
+        'RGB_bands': ('B3','B2','B1'),
+        'NIR_band': 'B4',
+        'cloudy_pix_flag': 'None',
+        'do_network_centrality': do_network_centrality,
+        'num_days_per_point': 90
+    },
+    'ERA5' : {
+        'collection_name': 'ECMWF/ERA5/DAILY',
+        'type': 'weather',
+        'precipitation_band': ['total_precipitation'],
+        'temperature_band': ['mean_2m_air_temperature'],
+        'num_days_per_point': 30
+    }
+}
+
+# select only those collections we want to use in this job
+data_collections = {key : value for key,value in data_collections.items() if key in collections_to_use}

--- a/pyveg/configs/collections.py
+++ b/pyveg/configs/collections.py
@@ -9,7 +9,7 @@ data_collections = {
         'mask_cloud': True,
         'cloudy_pix_frac': 50,
         'cloudy_pix_flag': 'CLOUDY_PIXEL_PERCENTAGE',
-        'min_date': '2016-01-01',
+        'min_date': '2015-01-01',
         'max_date': time.strftime("%Y-%m-%d"),
         'time_per_point': "1m"
     },
@@ -19,9 +19,9 @@ data_collections = {
         'RGB_bands': ['B4','B3','B2'],
         'NIR_band': 'B5',
         'cloudy_pix_flag': 'CLOUD_COVER',
-        'min_date': '2013-04-01',
+        'min_date': '2013-01-01',
         'max_date': time.strftime("%Y-%m-%d"),
-        'time_per_point': "3m"
+        'time_per_point': "1m"
     },
     'Landsat7' : {
         'collection_name': 'LANDSAT/LE07/C01/T1_SR',
@@ -31,7 +31,7 @@ data_collections = {
         'cloudy_pix_flag': 'CLOUD_COVER',
         'min_date': '1999-01-01',
         'max_date': time.strftime("%Y-%m-%d"),
-        'time_per_point': "3m"
+        'time_per_point': "1m"
     },
     'Landsat5' : {
         'collection_name': 'LANDSAT/LT05/C01/T1_SR',
@@ -39,9 +39,9 @@ data_collections = {
         'RGB_bands': ['B3','B2','B1'],
         'NIR_band': 'B4',
         'cloudy_pix_flag': 'None',
-        'min_date': '1988-01-01',
-        'max_date': '2003-01-01',
-        'time_per_point': "3m"
+        'min_date': '1984-01-01',
+        'max_date': '2013-01-01',
+        'time_per_point': "1m"
     },
     'Landsat4' : {
         'collection_name': 'LANDSAT/LT04/C01/T1_SR',
@@ -49,9 +49,9 @@ data_collections = {
         'RGB_bands': ['B3','B2','B1'],
         'NIR_band': 'B4',
         'cloudy_pix_flag': 'None',
-        'min_date': '1988-01-01',
-        'max_date': '2003-01-01',
-        'time_per_point': "3m"
+        'min_date': '1982-01-01',
+        'max_date': '1994-01-01',
+        'time_per_point': "1m"
     },
     'ERA5' : {
         'collection_name': 'ECMWF/ERA5/MONTHLY',

--- a/pyveg/configs/collections.py
+++ b/pyveg/configs/collections.py
@@ -1,3 +1,4 @@
+import time
 
 data_collections = {
     'Sentinel2' : {
@@ -8,6 +9,8 @@ data_collections = {
         'mask_cloud': True,
         'cloudy_pix_frac': 50,
         'cloudy_pix_flag': 'CLOUDY_PIXEL_PERCENTAGE',
+        'min_date': '2016-01-01',
+        'max_date': time.strftime("%Y-%m-%d"),
         'time_per_point': "1m"
     },
     'Landsat8' : {
@@ -16,6 +19,18 @@ data_collections = {
         'RGB_bands': ['B4','B3','B2'],
         'NIR_band': 'B5',
         'cloudy_pix_flag': 'CLOUD_COVER',
+        'min_date': '2013-04-01',
+        'max_date': time.strftime("%Y-%m-%d"),
+        'time_per_point': "3m"
+    },
+    'Landsat7' : {
+        'collection_name': 'LANDSAT/LE07/C01/T1_SR',
+        'data_type': 'vegetation',
+        'RGB_bands': ['B3','B2','B1'],
+        'NIR_band': 'B4',
+        'cloudy_pix_flag': 'CLOUD_COVER',
+        'min_date': '1999-01-01',
+        'max_date': time.strftime("%Y-%m-%d"),
         'time_per_point': "3m"
     },
     'Landsat5' : {
@@ -24,6 +39,8 @@ data_collections = {
         'RGB_bands': ['B3','B2','B1'],
         'NIR_band': 'B4',
         'cloudy_pix_flag': 'None',
+        'min_date': '1988-01-01',
+        'max_date': '2003-01-01',
         'time_per_point': "3m"
     },
     'Landsat4' : {
@@ -32,6 +49,8 @@ data_collections = {
         'RGB_bands': ['B3','B2','B1'],
         'NIR_band': 'B4',
         'cloudy_pix_flag': 'None',
+        'min_date': '1988-01-01',
+        'max_date': '2003-01-01',
         'time_per_point': "3m"
     },
     'ERA5' : {
@@ -39,6 +58,8 @@ data_collections = {
         'data_type': 'weather',
         'precipitation_band': ['total_precipitation'],
         'temperature_band': ['mean_2m_air_temperature'],
+        'min_date': '1979-01-01',
+        'max_date': time.strftime("%Y-%m-%d"),
         'time_per_point': "1m"
     }
 }

--- a/pyveg/scripts/run_pyveg_pipeline.py
+++ b/pyveg/scripts/run_pyveg_pipeline.py
@@ -11,7 +11,9 @@ import importlib.util
 import inspect
 from shutil import copyfile
 import re
+import datetime
 
+from pyveg.src.date_utils import get_date_range_for_collection
 from pyveg.src.pyveg_pipeline import Pipeline, Sequence
 from pyveg.src.download_modules import VegetationDownloader, WeatherDownloader
 from pyveg.src.processor_modules import (
@@ -22,6 +24,7 @@ from pyveg.src.processor_modules import (
 )
 
 from pyveg.src.combiner_modules import VegAndWeatherJsonCombiner
+
 
 
 def build_pipeline(config_file, from_cache=False):
@@ -68,6 +71,9 @@ def build_pipeline(config_file, from_cache=False):
         s = Sequence(coll)
         coll_dict = config.data_collections[coll]
         s.set_config(coll_dict)
+        # overwrite the date range with one that takes into account
+        # the limits of this collection
+        s.date_range = get_date_range_for_collection(config.date_range, coll_dict)
         # add modules to the sequence
         for module_name in config.modules_to_use[coll]:
             for n, c in inspect.getmembers(sys.modules[__name__]):

--- a/pyveg/src/date_utils.py
+++ b/pyveg/src/date_utils.py
@@ -83,7 +83,7 @@ def slice_time_period(start_date, end_date, period_length):
     match = re.search("^([\d]+)([dwmy])", period_length)
     if not match:
         raise RuntimeError("Period length must be in format '<int><d|w|m|y>', e.g. 30d")
-    
+
     num, units = match.groups()
     num = int(num)
     previous_date = start_datetime
@@ -128,3 +128,28 @@ def find_mid_period(start_time, end_time):
     mid = (t0 + timedelta(days=(td//2))).isoformat()
     mid_date = mid.split("T")[0]
     return mid_date
+
+
+
+def get_date_range_for_collection(date_range, coll_dict):
+    """
+    Return the intersection of the date range asked for by
+    the user, and the min and max dates for that collection.
+
+    Parameters
+    ==========
+    date_range: list or tuple of strings, format YYYY-MM-DD
+    coll_dict: dictionary containing min_date and max_date kyes
+
+    Returns
+    =======
+    tuple of strings, format YYYY-MM-DD
+    """
+    if not "min_date" in coll_dict.keys() or (not "max_date" in coll_dict.keys()):
+        return date_range
+    datetime_range = [dateparser.parse(d) for d in date_range]
+    collection_min =  dateparser.parse(coll_dict["min_date"])
+    collection_max =  dateparser.parse(coll_dict["max_date"])
+    date_min = datetime_range[0] if datetime_range[0] > collection_min else collection_min
+    date_max = datetime_range[1] if datetime_range[1] < collection_min else collection_max
+    return (date_min.isoformat().split("T")[0], date_max.isoformat().split("T")[0])

--- a/pyveg/tests/test_date_utils.py
+++ b/pyveg/tests/test_date_utils.py
@@ -71,3 +71,12 @@ def test_slice_time_period_by_years():
         assert datetime.fromisoformat(sub_periods[0][0]) == datetime.fromisoformat(start_date)
         assert datetime.fromisoformat(sub_periods[-1][1]) <= datetime.fromisoformat(end_date)
         assert len(sub_periods) == 5 // i
+
+
+def test_get_date_range_for_collection():
+    date_range = ("2010-01-01","2020-05-01")
+    coll_dict = {"min_date": "2015-01-01",
+                 "max_date": "2019-01-01"}
+    new_date_range = get_date_range_for_collection(date_range, coll_dict)
+    assert new_date_range[0] == "2015-01-01"
+    assert new_date_range[1] == "2019-01-01"


### PR DESCRIPTION
`collections.py` json structure now has "min_date" and "max_date" for each GEE collection.   When the user requests a date range for their job, only the overlap of the date range and the valid date for the collection will be used.

@samvanstroud could you have a quick look at whether the "min_date"/"max_date" values for the various landsat collections in `configs/collections.py` look sensible?  (I took some numbers from the GEE catalogue, but not sure if they're the best values).