### PR TITLE
Fix analysis preprocessing case where there are no missing veg entries

### DIFF
--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -564,6 +564,9 @@ def fill_veg_gaps(dfs, missing):
                 # construct missing rows
                 missing_rows = [pd.Series({"date": date}) for date in missing[col_name]]
 
+                if len(missing_rows) == 0:
+                    continue
+
                 # add back in missing values if necessary
                 df_ = df_.append(missing_rows, ignore_index=True).sort_values(by="date")
 


### PR DESCRIPTION
*Fix `analysis_preprocessing.fill_veg_gaps` to deal with situation where the `missing` list, describing missing points in the vegetation time series, is empty.
Closes #350