### PR TITLE
more useful error message for missing config file

### DIFF
--- a/pyveg/scripts/run_pyveg_pipeline.py
+++ b/pyveg/scripts/run_pyveg_pipeline.py
@@ -37,6 +37,8 @@ def build_pipeline(config_file, from_cache=False):
     """
     Load json config and instantiate modules
     """
+    if not os.path.exists(config_file):
+        raise FileNotFoundError("Unable to find config file {}".format(config_file))
 
     current_time = time.strftime("%Y-%m-%d_%H-%M-%S")
 


### PR DESCRIPTION
Better error message when running `pyveg_run_pipeline` if the config file isn't found.
Closes #354 