### PR TITLE
fix crash  in check_task_failed_dependencies if task has no depends_on

### DIFF
--- a/pyveg/src/batch_utils.py
+++ b/pyveg/src/batch_utils.py
@@ -258,6 +258,8 @@ def check_task_failed_dependencies(task, batch_service_client=None):
         batch_service_client = create_batch_client()
     if task.state != batchmodels.TaskState.active:
         return False
+    if not task.depends_on:
+        return False
     dependencies = task.depends_on.task_ids
     if len(dependencies) == 0:
         return False


### PR DESCRIPTION
Fix crash in `check_task_failed_dependency` if the task has no `depends_on` attribute.
Closes #355 