### PR TITLE
fix case where we try to do os.listdir on a temporary file

### DIFF
--- a/pyveg/src/batch_utils.py
+++ b/pyveg/src/batch_utils.py
@@ -315,8 +315,9 @@ def check_tasks_status(job_id, task_name_prefix="", batch_service_client=None):
         for task in tasks
         if task.state == batchmodels.TaskState.completed
     ]
+    num_success = sum(task_success)
     return {
-        "num_success": sum(task_success),
+        "num_success": num_success,
         "num_failed": len(task_success) - num_success,
         "num_running": num_running,
         "num_waiting": num_waiting,

--- a/pyveg/src/processor_modules.py
+++ b/pyveg/src/processor_modules.py
@@ -203,8 +203,13 @@ class ProcessorModule(BaseModule):
             )
 
         for date_string in date_strings:
-            logger.info(
-                "date string {} input exists {} output exists {}".format(
+            date_regex = "[\d]{4}-[\d]{2}-[\d]{2}"
+            if not re.search(date_regex, date_string):
+                logger.info("{}: {} not a date string".format(self.name, date_string))
+                continue
+            logger.debug(
+                "{}: date string {} input exists {} output exists {}".format(
+                    self.name,
                     date_string,
                     self.check_input_data_exists(date_string),
                     self.check_output_data_exists(date_string),
@@ -254,7 +259,7 @@ class ProcessorModule(BaseModule):
                         )
                     )
                     continue
-                logger.info(
+                logger.debug(
                     "has {} submitted all tasks? {}".format(
                         dependency_module.name, dependency_module.all_tasks_submitted
                     )
@@ -329,14 +334,14 @@ class ProcessorModule(BaseModule):
                 task_dict = self.create_task_dict(
                     "{}_{}".format(self.name, i), dates_per_task[i]
                 )
-                logger.info("{} adding task_dict {} to list".format(self.name, task_dict))
+                logger.debug("{} adding task_dict {} to list".format(self.name, task_dict))
                 task_dicts.append(task_dict)
         else:
             # we have a bunch of tasks from the previous Module in the Sequence
             for i, (k, v) in enumerate(task_dependencies.items()):
                 # key k will be the task_id of the old task.  v will be the list of dates.
                 task_dict = self.create_task_dict("{}_{}".format(self.name, i), v, [k])
-                logger.info(
+                logger.debug(
                     "{} adding task_dict with dependency {} to list".format(
                         self.name, task_dict
                     )
@@ -348,7 +353,7 @@ class ProcessorModule(BaseModule):
         else:
             # otherwise create a new job_id just for this module
             job_id = self.name + "_" + time.strftime("%Y-%m-%d_%H-%M-%S")
-        logger.info("{} about to submit tasks for job {}".format(self.name, job_id))
+        logger.info("{}: about to submit tasks for job {}".format(self.name, job_id))
         submitted_ok = batch_utils.submit_tasks(task_dicts, job_id)
         if submitted_ok:
             # store the task dict so any dependent modules can query it
@@ -356,7 +361,7 @@ class ProcessorModule(BaseModule):
                 td["task_id"]: td["config"]["dates_to_process"] for td in task_dicts
             }
             self.all_tasks_submitted = True
-            logger.info(
+            logger.debug(
                 "{} submitted all tasks ok, my task_dict is now {}".format(
                     self.name, self.batch_task_dict
                 )

--- a/pyveg/src/pyveg_pipeline.py
+++ b/pyveg/src/pyveg_pipeline.py
@@ -517,6 +517,8 @@ class BaseModule(object):
         or Azure blob storage.
         """
         if location_type == "local":
+            if not os.path.isdir(directory_path):
+                return []
             return os.listdir(directory_path)
         elif location_type == "azure":
             # first part of self.output_location should be the container name


### PR DESCRIPTION
* In ```pyveg_pipeline.list_directory``` check that the thing we're listing is a directory.
* In ```processor_modules.run_local``` check that the date strings look like dates.
* In ```processor_modules``` move a lot of batch-job-related output from "info" to "debug"
* Fix bug in ```batch_utils``` where "num_success" could was undefined.

Closes #358 