### PR TITLE
Feature/361 analysis azure

### DIFF
--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -41,6 +41,11 @@ from pyveg.src.plotting import (
 from pyveg.scripts.create_analysis_report import create_markdown_pdf_report
 from pyveg.scripts.upload_to_zenodo import upload_results
 
+try:
+    from pyveg.src import azure_utils
+except:
+    print("Unable to import azure_utils")
+
 
 def run_time_series_analysis(filename, output_dir, detrended=False):
     """
@@ -203,72 +208,92 @@ def run_early_warnings_resilience_analysis(filename, output_dir):
             )
 
 
-def analyse_gee_data(input_dir, spatial=False, upload_to_zenodo=False, upload_to_zenodo_test=False):
+def analyse_gee_data(input_location,
+                     input_location_type,
+                     output_dir,
+                     do_time_series=True,
+                     do_spatial=False,
+                     upload_to_zenodo=False,
+                     upload_to_zenodo_test=False):
     """
     Run analysis on dowloaded gee data
 
     Parameters
     ----------
-    input_dir : string
-        Path to directory with downloaded dada
-    do_spatial_plot: bool
-        Option to run spatial analysis and do plots
-    do_time_series_plot: bool
+    input_location : str
+        Location of results_summary.json output from pyveg_run_pipeline
+    input_location_type: str
+        Can be 'local' or 'azure'.
+    output_dir: str,
+        Location for outputs of the analysis
+    do_time_series: bool
         Option to run time-series analysis and do plots
+    do_spatial: bool
+        Option to run spatial analysis and do plots
+    upload_to_zenodo: bool
+        Upload results to the production Zenodo repo
+    upload_to_zenodo_test: bool
+        Upload results to the sandbox Zenodo repo
     """
+
+    # read the results_summary.json
+    input_json = read_results_summary(input_location, input_location_type)
 
     # preprocess input data
     ts_dirname, dfs = preprocess_data(
-        input_dir, n_smooth=4, resample=False, period="MS"
+        input_json, output_dir, n_smooth=4, resample=False, period="MS"
     )
 
     # get filenames of preprocessed data time series
     ts_filenames = [f for f in os.listdir(ts_dirname) if "time_series" in f]
 
     # put all analysis results in this dir
-    output_dir = os.path.join(input_dir, "analysis")
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir, exist_ok=True)
+    output_analysis_dir = os.path.join(output_dir, "analysis")
+    if not os.path.exists(output_analysis_dir):
+        os.makedirs(output_analysis_dir, exist_ok=True)
 
     print("\nRunning Analysis...")
     print("-" * len("Running Analysis..."))
 
     # plot the feature vectors
-    plot_feature_vector(output_dir)
+    plot_feature_vector(output_analysis_dir)
 
+    # time-series analysis and plotting
+    # -----------------------------------
     # for each time series
-    for filename in ts_filenames:
+    if do_time_series:
+        for filename in ts_filenames:
 
-        ts_file = os.path.join(ts_dirname, filename)
-        print(f'\n* Analysing "{ts_file}"...')
-        print("." * 50)
+            ts_file = os.path.join(ts_dirname, filename)
+            print(f'\n* Analysing "{ts_file}"...')
+            print("." * 50)
 
-        # run the standard or detrended analysis
-        if "detrended" in filename:
-            output_subdir = os.path.join(output_dir, "detrended")
-            run_time_series_analysis(ts_file, output_subdir, detrended=True)
+            # run the standard or detrended analysis
+            if "detrended" in filename:
+                output_subdir = os.path.join(output_analysis_dir, "detrended")
+                run_time_series_analysis(ts_file, output_subdir, detrended=True)
 
-            ews_subdir = os.path.join(output_dir, "resiliance/deseasonalised")
-            run_early_warnings_resilience_analysis(ts_file, ews_subdir)
+                ews_subdir = os.path.join(output_analysis_dir, "resiliance/deseasonalised")
+                run_early_warnings_resilience_analysis(ts_file, ews_subdir)
 
-        else:
-            output_subdir = output_dir
-            run_time_series_analysis(ts_file, output_subdir)
+            else:
+                output_subdir = output_analysis_dir
+                run_time_series_analysis(ts_file, output_subdir)
 
-            ews_subdir = os.path.join(output_dir, "resiliance/seasonal")
-            run_early_warnings_resilience_analysis(ts_file, ews_subdir)
+                ews_subdir = os.path.join(output_analysis_dir, "resiliance/seasonal")
+                run_early_warnings_resilience_analysis(ts_file, ews_subdir)
 
-        print("." * 50, "\n")
+            print("." * 50, "\n")
 
     # spatial analysis and plotting
     # ------------------------------------------------
-    if spatial:
+    if do_spatial:
 
         # from the dataframe, produce network metric figure for each avalaible date
         print("\nCreating spatial plots...")
 
         # create new subdir for time series analysis
-        spatial_subdir = os.path.join(output_dir, "spatial")
+        spatial_subdir = os.path.join(output_analysis_dir, "spatial")
         if not os.path.exists(spatial_subdir):
             os.makedirs(spatial_subdir, exist_ok=True)
 
@@ -280,8 +305,6 @@ def analyse_gee_data(input_dir, spatial=False, upload_to_zenodo=False, upload_to
                     data_df_geo_coarse, "offset50", spatial_subdir
                 )
     # ------------------------------------------------
-    # reporting
-    print('\nAnalysis complete.\n')
 
     print('\nCreating report.\n')
 
@@ -289,7 +312,7 @@ def analyse_gee_data(input_dir, spatial=False, upload_to_zenodo=False, upload_to
         if collection_name == 'COPERNICUS/S2' or 'LANDSAT' in collection_name:
 
             try:
-                create_markdown_pdf_report(input_dir,collection_name)
+                create_markdown_pdf_report(output_dir, collection_name)
             except Exception as e:
                 print ("Warning: A problem was found, the report was not created. There might be missing figures needed "
                               "for the report or a problem with the pandoc installation.")
@@ -300,16 +323,16 @@ def analyse_gee_data(input_dir, spatial=False, upload_to_zenodo=False, upload_to
     # uploading
     if upload_to_zenodo or upload_to_zenodo_test:
         print('\nUploading results to Zenodo.\n')
-        coll_search = re.search("([Ss]entinel[-]?[\d])|([Ll]andsat[-]?[\d])", input_dir)
+        coll_search = re.search("([Ss]entinel[-]?[\d])|([Ll]andsat[-]?[\d])", input_location)
         if coll_search:
             collection = coll_search.groups()[0] if coll_search.groups()[0] \
                 else coll_search.groups()[1]
 
             uploaded = upload_results(collection,
-                                      input_dir,
+                                      output_dir,
                                       "local",
-                                      input_dir,
-                                      "local",
+                                      input_location,
+                                      input_location_type,
                                       upload_to_zenodo_test)
             if uploaded:
                 print("Uploaded results_summary.json and time series outputs to Zenodo.")
@@ -324,6 +347,46 @@ def analyse_gee_data(input_dir, spatial=False, upload_to_zenodo=False, upload_to
     print("\nAnalysis complete.\n")
 
 
+def read_results_summary(input_location, input_location_type):
+    """
+    Read the results_summary.json, either from local storage or from Azure blob storage.
+
+    Parameters
+    ==========
+    input_location: str, directory or container with results_summary.json in
+    input_location_type: str: 'local' or 'azure'
+
+    Returns
+    =======
+    json_data: dict, the contents of results_summary.json
+    """
+    json_name = "results_summary.json"
+    if input_location_type == "local":
+        json_filepath = os.path.join(input_location, json_name)
+        if not os.path.exists(json_filepath):
+            raise FileNotFoundError("Unable to find {}".format(json_filepath))
+        json_data = json.load(open(json_filepath))
+        return json_data
+    elif input_location_type == "azure":
+        subdirs = azure_utils.list_directory(input_location, input_location)
+        print("Found subdirs {}".format(subdirs))
+        for subdir in subdirs:
+            print("looking at subdir {}".format(subdir))
+            if "combine" in subdir:
+                files = azure_utils.list_directory(input_location+"/"+subdir,
+                                                   input_location)
+                if json_name in files:
+                    return azure_utils.read_json(input_location+"/"+subdir+"/"+json_name,
+                                                 input_location)
+                else:
+                    raise RuntimeError("No {} found in {}".format(json_name, subdir))
+        return {}
+    else:
+        raise RuntimeError("input_location_type needs to be either 'local' or 'azure'")
+
+
+
+
 def main():
     """
     CLI interface for gee data analysis.
@@ -336,7 +399,7 @@ def main():
         help="results directory from `download_gee_data` script, containing `results_summary.json`",
     )
     parser.add_argument(
-        "--input_blob",
+        "--input_container",
         help="results location on blob storage from `download_gee_data` script, containing `results_summary.json`",
     )
     parser.add_argument(
@@ -344,8 +407,12 @@ def main():
         help="location where analysis plots will be put.  If not specified, will use input_dir",
     )
     parser.add_argument(
+        "--dont_do_time_series", action="store_true", default=False
+    )  # if set, disable the time-series analysis
+
+    parser.add_argument(
         "--spatial", action="store_true", default=False
-    )  # off by deafult as this takes a non-negligable amount of time
+    )  # off by default as this takes a non-negligable amount of time
 
     parser.add_argument(
         "--upload_to_zenodo", action="store_true", default=False
@@ -361,12 +428,35 @@ def main():
 
     # parse args
     args = parser.parse_args()
-    input_dir = args.input_dir
-    spatial = args.spatial
+    # check we have the bare minimum of args set that we need
+    output_dir = args.output_dir if args.output_dir else args.input_dir
+    if not output_dir:
+        raise RuntimeError("Need to specify --output_dir argument if reading from Azure blob storage")
+
+    # read the input json, using either input_dir or input_container arguments
+    if args.input_dir and args.input_container:
+        raise RuntimeError("Please use only one of --input_dir (for local input) or --input_location (for Azure)")
+    if args.input_dir:
+        input_location = args.input_dir
+        input_location_type = "local"
+    else:
+        input_location = args.input_container
+        input_location_type = "azure"
+
+
+
+    do_time_series = not args.dont_do_time_series
+    do_spatial = args.spatial
     upload_to_zenodo = args.upload_to_zenodo
     upload_to_zenodo_test = args.upload_to_zenodo_test
     # run analysis code
-    analyse_gee_data(input_dir, spatial, upload_to_zenodo, upload_to_zenodo_test)
+    analyse_gee_data(input_location,
+                     input_location_type,
+                     output_dir,
+                     do_time_series,
+                     do_spatial,
+                     upload_to_zenodo,
+                     upload_to_zenodo_test)
 
 
 if __name__ == "__main__":

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -309,6 +309,14 @@ def main():
         help="results directory from `download_gee_data` script, containing `results_summary.json`",
     )
     parser.add_argument(
+        "--input_blob",
+        help="results location on blob storage from `download_gee_data` script, containing `results_summary.json`",
+    )
+    parser.add_argument(
+        "--output_dir",
+        help="location where analysis plots will be put.  If not specified, will use input_dir",
+    )
+    parser.add_argument(
         "--spatial", action="store_true", default=False
     )  # off by deafult as this takes a non-negligable amount of time
 

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -9,10 +9,12 @@ Plots are produced from the processed data.
 
 import os
 import argparse
+import json
 import re
 
 import pandas as pd
 import ewstools
+
 from pyveg.src.analysis_preprocessing import preprocess_data
 
 from pyveg.src.data_analysis_utils import (
@@ -209,8 +211,8 @@ def run_early_warnings_resilience_analysis(filename, output_dir):
 
 
 def analyse_gee_data(input_location,
-                     input_location_type,
-                     output_dir,
+                     input_location_type="local",
+                     output_dir=None,
                      do_time_series=True,
                      do_spatial=False,
                      upload_to_zenodo=False,
@@ -225,7 +227,7 @@ def analyse_gee_data(input_location,
     input_location_type: str
         Can be 'local' or 'azure'.
     output_dir: str,
-        Location for outputs of the analysis
+        Location for outputs of the analysis. If None, use input_location
     do_time_series: bool
         Option to run time-series analysis and do plots
     do_spatial: bool
@@ -236,6 +238,8 @@ def analyse_gee_data(input_location,
         Upload results to the sandbox Zenodo repo
     """
 
+    if not output_dir:
+        output_dir = input_location
     # read the results_summary.json
     input_json = read_results_summary(input_location, input_location_type)
 

--- a/pyveg/scripts/create_analysis_report.py
+++ b/pyveg/scripts/create_analysis_report.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pypandoc
 
 
-def create_markdown_pdf_report(path, collection_name ='Sentinel2'):
+def create_markdown_pdf_report(path, collection_name):
 
     # getting the right suffix from the satelite to analyse
     if collection_name == 'COPERNICUS/S2':
@@ -29,6 +29,9 @@ def create_markdown_pdf_report(path, collection_name ='Sentinel2'):
         collection = 'Landsat4'
         satellite_suffix = 'L4'
 
+    else:
+        raise RuntimeError("Unknown collection_name {}".format(collection_name))
+
     current_path = Path(path)
     current_dirs_parent = str(current_path.parent)
 
@@ -41,9 +44,9 @@ def create_markdown_pdf_report(path, collection_name ='Sentinel2'):
 
     except:
         # in case the directory does not have the right name with coordinates
-        output_path = os.path.join(path,'analysis_report_'+collection_name)
+        output_path = os.path.join(path,'analysis_report_'+collection)
         mdFile = MdUtils(file_name=output_path,
-                         title='Results for ' + collection_name)
+                         title='Results for ' + collection)
 
 
     # Time series figures

--- a/pyveg/tests/test_analyse_gee_data.py
+++ b/pyveg/tests/test_analyse_gee_data.py
@@ -3,6 +3,7 @@ Test the functions in analyse_gee_data.py
 """
 import os
 import shutil
+import json
 from pyveg.scripts.analyse_gee_data import analyse_gee_data
 
 
@@ -18,7 +19,7 @@ def test_analyse_gee_data():
         shutil.rmtree(analysis_path)
 
     # run script
-    analyse_gee_data(input_dir, spatial=True)
+    analyse_gee_data(input_dir, do_spatial=True)
 
     # assert script produced output
     assert os.path.exists(analysis_path) == True

--- a/pyveg/tests/test_analysis_preprocessing.py
+++ b/pyveg/tests/test_analysis_preprocessing.py
@@ -1,19 +1,22 @@
 """
 Test the functions in analysis_preprocessing.py
 """
+import os
+import json
 
-from pyveg.src.analysis_preprocessing import *
+from pyveg.src.analysis_preprocessing import read_json_to_dataframes
 
 
 def test_read_json_to_dataframes():
-    test_df_dict = read_json_to_dataframes(
-        os.path.join(
+
+    json_filename = os.path.join(
             os.path.dirname(__file__),
             "..",
             "testdata",
             "network_json_data/test-results-summary.json",
-        )
     )
+    summary_json = json.load(open(json_filename))
+    test_df_dict = read_json_to_dataframes(summary_json)
 
     dict_len = len(test_df_dict.keys())
     test_df = test_df_dict["COPERNICUS/S2"]

--- a/pyveg/tests/test_data_analysis_utils.py
+++ b/pyveg/tests/test_data_analysis_utils.py
@@ -4,20 +4,22 @@ Test the functions in data_analysis_utils.py
 
 import os
 import shutil
+import json
 
 from pyveg.src.data_analysis_utils import *
 from pyveg.src.analysis_preprocessing import *
 
 
 def test_coarse_dataframe():
-    test_df = read_json_to_dataframes(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "testdata",
-            "network_json_data/test-results-summary.json",
-        )
+
+    json_filename = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "testdata",
+        "network_json_data/test-results-summary.json",
     )
+    results_dict = json.load(open(json_filename))
+    test_df = read_json_to_dataframes(results_dict)
 
     data_df = convert_to_geopandas(test_df["COPERNICUS/S2"])
 
@@ -36,14 +38,14 @@ def test_create_lat_long_metric_figures():
         os.path.dirname(__file__), "..", "testdata", "network_json_data/"
     )
 
-    test_df = read_json_to_dataframes(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "testdata",
-            "network_json_data/test-results-summary.json",
-        )
+    json_filename = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "testdata",
+        "network_json_data/test-results-summary.json",
     )
+    summary_json = json.load(open(json_filename))
+    test_df = read_json_to_dataframes(summary_json)
 
     data_df = convert_to_geopandas(test_df["COPERNICUS/S2"])
 
@@ -73,7 +75,8 @@ def test_moving_window_analysis():
         "testdata",
         "network_json_data/results_summary.json",
     )
-    dfs = read_json_to_dataframes(path_to_dict)
+    results_json = json.load(open(path_to_dict))
+    dfs = read_json_to_dataframes(results_json)
     time_series_dfs = make_time_series(dfs.copy())
 
     ar1_var_df = moving_window_analysis(


### PR DESCRIPTION
Add extra command line arguments to `pyveg_analyse_gee_data` to deal with the possibility that `results_summary.json` could be on Azure blob storage.
If this is the case, rather than ```--input_dir``` the user should specify ```--input_container``` and give the name of the container on blob storage.   The user will also need to specify ```--output_dir``` to determine where the outputs of the analysis would go (in the past this was just the same as input_dir).   
Until we have a system for putting metadata into the `results_summary.json` file, the analysis-report creation and upload to zenodo rely on parsing information from the filepath.   Therefore for these aspects to work correctly, output_dir needs to be of the format 
`*<collection>*/*_<longitude>_<latitude>`