### PR TITLE
Bugfix/390 output location windows

### DIFF
--- a/pyveg/src/azure_utils.py
+++ b/pyveg/src/azure_utils.py
@@ -45,6 +45,9 @@ def sanitize_container_name(orig_name):
         else:
             sanitized_name += character.lower()
             previous_character = character
+    if "\\" in sanitized_name:
+        sanitized_name = sanitized_name.replace("\\","/")
+
     return sanitized_name
 
 

--- a/pyveg/src/azure_utils.py
+++ b/pyveg/src/azure_utils.py
@@ -164,7 +164,7 @@ def remove_container_name_from_blob_path(blob_path, container_name):
             container_name_found = True
     if len(blob_name_parts) == 0:
         return ""
-    return os.path.join(*blob_name_parts)
+    return "/".join(blob_name_parts)
 
 
 def delete_blob(blob_name, container_name, bbs=None):

--- a/pyveg/src/combiner_modules.py
+++ b/pyveg/src/combiner_modules.py
@@ -147,14 +147,14 @@ class VegAndWeatherJsonCombiner(CombinerModule):
                 veg_time_series[date_string] = None
             # if there is no JSON directory for this date, add a null entry
             if "JSON" not in self.list_directory(
-                os.path.join(self.input_veg_location, date_string),
+                self.join_path(self.input_veg_location, date_string),
                 self.input_veg_location_type,
             ):
                 veg_time_series[date_string] = None
                 continue
             # find the subdirs of the JSON directory
             subdirs = self.list_directory(
-                os.path.join(self.input_veg_location, date_string, "JSON"),
+                self.join_path(self.input_veg_location, date_string, "JSON"),
                 self.input_veg_location_type,
             )
             veg_lists = []
@@ -162,14 +162,14 @@ class VegAndWeatherJsonCombiner(CombinerModule):
                 logger.debug(
                     "{}: getting vegetation time series for {}".format(
                         self.name,
-                        os.path.join(
+                        self.join_path(
                             self.input_veg_location, date_string, "JSON", subdir
                         ),
                     )
                 )
                 # list the JSON subdirectories and find any .json files in them
                 dir_contents = self.list_directory(
-                    os.path.join(self.input_veg_location, date_string, "JSON", subdir),
+                    self.join_path(self.input_veg_location, date_string, "JSON", subdir),
                     self.input_veg_location_type,
                 )
                 json_files = [
@@ -177,7 +177,7 @@ class VegAndWeatherJsonCombiner(CombinerModule):
                 ]
                 for filename in json_files:
                     j = self.get_json(
-                        os.path.join(
+                        self.join_path(
                             self.input_veg_location,
                             date_string,
                             "JSON",
@@ -203,7 +203,7 @@ class VegAndWeatherJsonCombiner(CombinerModule):
         for date_string in date_strings:
 
             weather_json = self.get_json(
-                os.path.join(
+                self.join_path(
                     self.input_weather_location,
                     date_string,
                     "JSON",
@@ -273,7 +273,7 @@ class VegAndWeatherJsonCombiner(CombinerModule):
 
         logger.info("{}: Wrote output to {}".format(
             self.name,
-            os.path.join(self.output_location, self.output_filename)
+            self.join_path(self.output_location, self.output_filename)
         )
         )
         self.is_finished = True

--- a/pyveg/src/download_modules.py
+++ b/pyveg/src/download_modules.py
@@ -188,7 +188,7 @@ class DownloaderModule(BaseModule):
         download_locations = []
         for date_range in date_ranges:
             mid_date = find_mid_period(date_range[0], date_range[1])
-            location = os.path.join(self.output_location, mid_date, "RAW")
+            location = self.join_path(self.output_location, mid_date, "RAW")
             logger.debug("{} Will check for existing files in {}".format(self.name, location))
             if not self.replace_existing_files and self.check_for_existing_files(
                 location, self.num_files_per_point

--- a/pyveg/src/processor_modules.py
+++ b/pyveg/src/processor_modules.py
@@ -105,7 +105,7 @@ class ProcessorModule(BaseModule):
         """
         for i in range(len(self.input_location_subdirs)):
             if not self.input_location_subdirs[i] in self.list_directory(
-                os.path.join(
+                self.join_path(
                     self.input_location, date_string, *(self.input_location_subdirs[:i])
                 ),
                 self.input_location_type,
@@ -114,7 +114,7 @@ class ProcessorModule(BaseModule):
             if (
                 len(
                     self.list_directory(
-                        os.path.join(
+                        self.join_path(
                             self.input_location,
                             date_string,
                             *(self.input_location_subdirs),
@@ -143,7 +143,7 @@ class ProcessorModule(BaseModule):
              AND self.replace_existing_files is set to False
         False otherwise
         """
-        output_location = os.path.join(
+        output_location = self.join_path(
             self.output_location, date_string, *(self.output_location_subdirs)
         )
         return self.check_for_existing_files(output_location, self.num_files_per_point)
@@ -454,16 +454,16 @@ class VegetationImageProcessor(ProcessorModule):
         """
 
         if "SUB" in image_type:
-            output_location = os.path.join(self.output_location, date_string, "SPLIT")
+            output_location = self.join_path(self.output_location, date_string, "SPLIT")
         else:
-            output_location = os.path.join(
+            output_location = self.join_path(
                 self.output_location, date_string, "PROCESSED"
             )
         # filename is the date, coordinates, and image type
         filename = f"{date_string}_{coords_string}_{image_type}.png"
 
         # full path is dir + filename
-        full_path = os.path.join(output_location, filename)
+        full_path = self.join_path(output_location, filename)
 
         return full_path
 
@@ -576,7 +576,7 @@ class VegetationImageProcessor(ProcessorModule):
             return True
 
         # If no files already there, proceed.
-        input_filepath = os.path.join(
+        input_filepath = self.join_path(
             self.input_location, date_string, *(self.input_location_subdirs)
         )
         logger.info("{} processing files in {}".format(self.name, input_filepath))
@@ -595,13 +595,13 @@ class VegetationImageProcessor(ProcessorModule):
         for icol, col in enumerate("rgb"):
             band = self.RGB_bands[icol]
             filename = self.get_file(
-                os.path.join(input_filepath, "download.{}.tif".format(band)),
+                self.join_path(input_filepath, "download.{}.tif".format(band)),
                 self.input_location_type,
             )
             band_dict[col] = {"band": band, "filename": filename}
 
         logger.info(filenames)
-        tif_filebase = os.path.join(input_filepath, filenames[0].split(".")[0])
+        tif_filebase = self.join_path(input_filepath, filenames[0].split(".")[0])
 
         # save the rgb image
         rgb_ok = self.save_rgb_image(band_dict, date_string, coords_string)
@@ -611,7 +611,7 @@ class VegetationImageProcessor(ProcessorModule):
 
         # save the NDVI image
         ndvi_tif = self.get_file(
-            os.path.join(input_filepath, "download.NDVI.tif"), self.input_location_type
+            self.join_path(input_filepath, "download.NDVI.tif"), self.input_location_type
         )
         ndvi_image = scale_tif(ndvi_tif)
         ndvi_filepath = self.construct_image_savepath(
@@ -677,7 +677,7 @@ class WeatherImageToJSON(ProcessorModule):
             logger.info("{} will not process date {}".format(self.name, date_string))
             return True
         logger.info("{}: Processing date {}".format(self.name, date_string))
-        input_location = os.path.join(
+        input_location = self.join_path(
             self.input_location, date_string, *(self.input_location_subdirs)
         )
         for filename in self.list_directory(input_location, self.input_location_type):
@@ -685,7 +685,7 @@ class WeatherImageToJSON(ProcessorModule):
                 name_variable = (filename.split("."))[1]
                 variable_array = cv.imread(
                     self.get_file(
-                        os.path.join(input_location, filename), self.input_location_type
+                        self.join_path(input_location, filename), self.input_location_type
                     ),
                     cv.IMREAD_ANYDEPTH,
                 )
@@ -694,7 +694,7 @@ class WeatherImageToJSON(ProcessorModule):
         self.save_json(
             metrics_dict,
             "weather_data.json",
-            os.path.join(
+            self.join_path(
                 self.output_location, date_string, *(self.output_location_subdirs)
             ),
             self.output_location_type,
@@ -775,7 +775,7 @@ class NetworkCentralityCalculator(ProcessorModule):
         rgb_filename = re.sub("BWNDVI", "RGB", ndvi_filename)
         rgb_img = Image.open(
             self.get_file(
-                os.path.join(input_path, rgb_filename), self.input_location_type
+                self.join_path(input_path, rgb_filename), self.input_location_type
             )
         )
         img_ok = check_image_ok(rgb_img, 0.05)
@@ -794,7 +794,7 @@ class NetworkCentralityCalculator(ProcessorModule):
             return True
         # see if there is already a network_centralities.json file in
         # the output location - if so, skip
-        output_location = os.path.join(
+        output_location = self.join_path(
             self.output_location, date_string, *(self.output_location_subdirs)
         )
         if (not self.replace_existing_files) and self.check_for_existing_files(
@@ -802,7 +802,7 @@ class NetworkCentralityCalculator(ProcessorModule):
         ):
             return True
 
-        input_path = os.path.join(
+        input_path = self.join_path(
             self.input_location, date_string, *(self.input_location_subdirs)
         )
         all_input_files = self.list_directory(input_path, self.input_location_type)
@@ -831,7 +831,7 @@ class NetworkCentralityCalculator(ProcessorModule):
                 (
                     i,
                     self.get_file(
-                        os.path.join(input_path, filename), self.input_location_type
+                        self.join_path(input_path, filename), self.input_location_type
                     ),
                     tmp_json_dir,
                     date_string,
@@ -883,7 +883,7 @@ class NDVICalculator(ProcessorModule):
         looks OK.
         """
         rgb_filename = re.sub("NDVI", "RGB", ndvi_filename)
-        rgb_img = self.get_image(os.path.join(input_path, rgb_filename))
+        rgb_img = self.get_image(self.join_path(input_path, rgb_filename))
 
         img_ok = check_image_ok(rgb_img, 0.05)
         return img_ok
@@ -936,7 +936,7 @@ class NDVICalculator(ProcessorModule):
 
         # see if there is already a ndvi.json file in
         # the output location - if so, skip
-        output_location = os.path.join(
+        output_location = self.join_path(
             self.output_location, date_string, *(self.output_location_subdirs)
         )
         if (not self.replace_existing_files) and self.check_for_existing_files(
@@ -944,7 +944,7 @@ class NDVICalculator(ProcessorModule):
         ):
             return True
 
-        input_path = os.path.join(
+        input_path = self.join_path(
             self.input_location, date_string, *(self.input_location_subdirs)
         )
         all_input_files = self.list_directory(input_path, self.input_location_type)
@@ -970,7 +970,7 @@ class NDVICalculator(ProcessorModule):
         for ndvi_file in input_files:
             coords_string = find_coords_string(ndvi_file)
             ndvi_dict = self.process_sub_image(
-                os.path.join(input_path, ndvi_file), date_string, coords_string
+                self.join_path(input_path, ndvi_file), date_string, coords_string
             )
             ndvi_vals.append(ndvi_dict)
 

--- a/pyveg/src/pyveg_pipeline.py
+++ b/pyveg/src/pyveg_pipeline.py
@@ -182,15 +182,35 @@ class Sequence(object):
 
         return self
 
+    def join_path(self, *path_elements):
+        """
+        If output_location_type is 'local', we will just use
+        os.path.join, which puts a "/" separator in for posix, or "\" for windows.
+        However, if output_location_type is 'azure', we always want "/".
+
+        Parameters
+        ==========
+        path_elements: list of strings.  Directory-like path elements.
+
+        Returns
+        =======
+        path: str, the path elements joined by "/" or "\".
+        """
+        if self.output_location_type == "azure":
+            path = "/".join(path_elements)
+        else:
+            path = os.path.join(*path_elements)
+        return path
+
     def set_output_location(self):
         if self.parent:
-            self.output_location = os.path.join(
+            self.output_location_type = self.parent.output_location_type
+            self.output_location = self.join_path(
                 self.parent.output_location,
                 f"gee_{self.coords[0]}_{self.coords[1]}"
                 + "_"
                 + self.name.replace("/", "-"),
             )
-            self.output_location_type = self.parent.output_location_type
         else:
             self.output_location = (
                 f"gee_{self.coords[0]}_{self.coords[1]}"
@@ -468,6 +488,26 @@ class BaseModule(object):
         output += "        =======================\n\n"
         return output
 
+    def join_path(self, *path_elements):
+        """
+        If output_location_type is 'local', we will just use
+        os.path.join, which puts a "/" separator in for posix, or "\" for windows.
+        However, if output_location_type is 'azure', we always want "/".
+
+        Parameters
+        ==========
+        path_elements: list of strings.  Directory-like path elements.
+
+        Returns
+        =======
+        path: str, the path elements joined by "/" or "\".
+        """
+        if self.output_location_type == "azure":
+            path = "/".join(path_elements)
+        else:
+            path = os.path.join(*path_elements)
+        return path
+
     def copy_to_output_location(self, tmpdir, output_location, file_endings=[]):
         """
         Copy contents of a temporary directory to a specified output location.
@@ -486,15 +526,8 @@ class BaseModule(object):
                     if file_endings:
                         for ending in file_endings:
                             if filename.endswith(ending):
-                                copyfile(os.path.join(root,filename),os.path.join(output_location,filename))
-                                #subprocess.run(
-                                 #   [
-                                        #"-r"
-                                #        "cp",
-                                #        os.path.join(root, filename),
-                                #        os.path.join(output_location, filename),
-                                #    ]
-                                #)
+                                copyfile(os.path.join(root,filename),
+                                         os.path.join(output_location,filename))
                     else:
                         subprocess.run(
                             [


### PR DESCRIPTION
When running on Windows, `os.path.join` will build paths using "\", which is correct for local storage, but when using "output_location_type" is "azure", we always need to use "/".

This change adds a function `join_path` that uses the correct separator based on what "output_location_type" is set to.

Also in "azure_utils.py" ensure we use `"/".join` rather than `os.path.join`.