### PR TITLE
Bugfix/368 ensuring a timeseries

### DIFF
--- a/pyveg/configs/config_all.py
+++ b/pyveg/configs/config_all.py
@@ -16,7 +16,7 @@ coordinate_id = "00"
 entry = coordinate_store.loc[coordinate_id]
 coordinates = (entry.longitude, entry.latitude)
 
-date_range = ["2016-01-01", "2016-02-01"]
+date_range = ["2016-01-01", "2016-04-01"]
 
 # From the dictionary entries in data_collections.py, which shall we use
 # (these will become "Sequences")

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -266,8 +266,9 @@ def analyse_gee_data(input_location,
     # time-series analysis and plotting
     # check first if data is a time series
     ts_df = pd.read_csv(os.path.join(ts_dirname,ts_filenames[0]))
-    if ts_df.shape[0]<=1:
-        print ('WARNING: Only one date point, not possible to do a time series analysis')
+    size_ts = ts_df.shape[0]
+    if size_ts <= 3:
+        print ('WARNING: Less than 3 times points, not possible to do a time series analysis')
         do_time_series = False
     # -----------------------------------
 
@@ -291,15 +292,19 @@ def analyse_gee_data(input_location,
                 output_subdir = os.path.join(output_analysis_dir, "detrended")
                 run_time_series_analysis(ts_file, output_subdir, detrended=True)
 
-                ews_subdir = os.path.join(output_analysis_dir, "resiliance/deseasonalised")
-                run_early_warnings_resilience_analysis(ts_file, ews_subdir)
+                # resilience analysis only done in large enough time series
+                if size_ts > 12:
+                    ews_subdir = os.path.join(output_analysis_dir, "resiliance/deseasonalised")
+                    run_early_warnings_resilience_analysis(ts_file, ews_subdir)
 
             else:
                 output_subdir = output_analysis_dir
                 run_time_series_analysis(ts_file, output_subdir)
 
-                ews_subdir = os.path.join(output_analysis_dir, "resiliance/seasonal")
-                run_early_warnings_resilience_analysis(ts_file, ews_subdir)
+                # resilience analysis only done in large enough time series
+                if size_ts > 12:
+                    ews_subdir = os.path.join(output_analysis_dir, "resiliance/seasonal")
+                    run_early_warnings_resilience_analysis(ts_file, ews_subdir)
 
             print("." * 50, "\n")
 
@@ -330,7 +335,7 @@ def analyse_gee_data(input_location,
         if collection_name == 'COPERNICUS/S2' or 'LANDSAT' in collection_name:
 
             try:
-                create_markdown_pdf_report(output_dir, collection_name,do_time_series)
+                create_markdown_pdf_report(output_dir, collection_name,do_time_series,size_ts)
             except Exception as e:
                 print ("Warning: A problem was found, the report was not created. There might be missing figures needed "
                               "for the report or a problem with the pandoc installation.")

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -267,7 +267,7 @@ def analyse_gee_data(input_location,
     # check first if data is a time series
     ts_df = pd.read_csv(os.path.join(ts_dirname,ts_filenames[0]))
     size_ts = ts_df.shape[0]
-    if size_ts <= 3:
+    if size_ts <= 2:
         print ('WARNING: Less than 3 times points, not possible to do a time series analysis')
         do_time_series = False
     # -----------------------------------

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -264,7 +264,14 @@ def analyse_gee_data(input_location,
     plot_feature_vector(output_analysis_dir)
 
     # time-series analysis and plotting
+    # check first if data is a time series
+    ts_df = pd.read_csv(os.path.join(ts_dirname,ts_filenames[0]))
+    if ts_df.shape[0]<=1:
+        print ('WARNING: Only one date point, not possible to do a time series analysis')
+        do_time_series = False
     # -----------------------------------
+
+
     # for each time series
     if do_time_series:
 
@@ -323,7 +330,7 @@ def analyse_gee_data(input_location,
         if collection_name == 'COPERNICUS/S2' or 'LANDSAT' in collection_name:
 
             try:
-                create_markdown_pdf_report(output_dir, collection_name)
+                create_markdown_pdf_report(output_dir, collection_name,do_time_series)
             except Exception as e:
                 print ("Warning: A problem was found, the report was not created. There might be missing figures needed "
                               "for the report or a problem with the pandoc installation.")

--- a/pyveg/scripts/create_analysis_report.py
+++ b/pyveg/scripts/create_analysis_report.py
@@ -48,11 +48,12 @@ def create_markdown_pdf_report(path, collection_name, do_timeseries):
         mdFile = MdUtils(file_name=output_path,
                          title='Results for ' + collection)
 
+    count = 0
+
     if do_timeseries:
         # Time series figures
         mdFile.new_header(level=1, title='Time series')
         ts_path = os.path.join(path,'analysis','time-series')
-        count = 0
         count = count + 1
         mdFile.new_line(mdFile.new_inline_image(text='Time series Offset50', path=os.path.join(ts_path,satellite_suffix+'-time-series_smooth.png')))
         #mdFile.new_paragraph('Figure '+str(count)+': '+'Time series Offset50')

--- a/pyveg/scripts/create_analysis_report.py
+++ b/pyveg/scripts/create_analysis_report.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pypandoc
 
 
-def create_markdown_pdf_report(path, collection_name, do_timeseries):
+def create_markdown_pdf_report(path, collection_name, do_timeseries, size_ts):
 
     # getting the right suffix from the satelite to analyse
     if collection_name == 'COPERNICUS/S2':
@@ -76,20 +76,21 @@ def create_markdown_pdf_report(path, collection_name, do_timeseries):
         #mdFile.new_paragraph('Figure '+str(count)+': '+'STL NDVI')
         mdFile.new_line('')
 
-        # Early warning figures
-        mdFile.new_header(level=1, title='Early warnings analysis')
-        ews_path = os.path.join(path, 'analysis', 'resiliance','deseasonalised','ewstools')
+        if size_ts > 12:
+            # Early warning figures
+            mdFile.new_header(level=1, title='Early warnings analysis')
+            ews_path = os.path.join(path, 'analysis', 'resiliance','deseasonalised','ewstools')
 
-        count = count +1
-        mdFile.new_line(mdFile.new_inline_image(text='EWS Offset50', path=os.path.join(ews_path, satellite_suffix+'-offset50-mean-ews.png')))
-        #mdFile.new_paragraph('Figure '+str(count)+': '+'EWS Offset50')
-        mdFile.new_line()
+            count = count +1
+            mdFile.new_line(mdFile.new_inline_image(text='EWS Offset50', path=os.path.join(ews_path, satellite_suffix+'-offset50-mean-ews.png')))
+            #mdFile.new_paragraph('Figure '+str(count)+': '+'EWS Offset50')
+            mdFile.new_line()
 
 
-        count = count +1
-        mdFile.new_line(
-        mdFile.new_inline_image(text='EWS NDVI', path=os.path.join(ews_path, satellite_suffix+'-ndvi-mean-ews.png')))
-        mdFile.new_line('')
+            count = count +1
+            mdFile.new_line(
+            mdFile.new_inline_image(text='EWS NDVI', path=os.path.join(ews_path, satellite_suffix+'-ndvi-mean-ews.png')))
+            mdFile.new_line('')
 
     mdFile.new_header(level=1, title='RGB images through time')  # style is set 'atx' format by default.
 

--- a/pyveg/scripts/create_analysis_report.py
+++ b/pyveg/scripts/create_analysis_report.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pypandoc
 
 
-def create_markdown_pdf_report(path, collection_name):
+def create_markdown_pdf_report(path, collection_name, do_timeseries):
 
     # getting the right suffix from the satelite to analyse
     if collection_name == 'COPERNICUS/S2':
@@ -48,47 +48,47 @@ def create_markdown_pdf_report(path, collection_name):
         mdFile = MdUtils(file_name=output_path,
                          title='Results for ' + collection)
 
+    if do_timeseries:
+        # Time series figures
+        mdFile.new_header(level=1, title='Time series')
+        ts_path = os.path.join(path,'analysis','time-series')
+        count = 0
+        count = count + 1
+        mdFile.new_line(mdFile.new_inline_image(text='Time series Offset50', path=os.path.join(ts_path,satellite_suffix+'-time-series_smooth.png')))
+        #mdFile.new_paragraph('Figure '+str(count)+': '+'Time series Offset50')
 
-    # Time series figures
-    mdFile.new_header(level=1, title='Time series')
-    ts_path = os.path.join(path,'analysis','time-series')
-    count = 0
-    count = count + 1
-    mdFile.new_line(mdFile.new_inline_image(text='Time series Offset50', path=os.path.join(ts_path,satellite_suffix+'-time-series_smooth.png')))
-    #mdFile.new_paragraph('Figure '+str(count)+': '+'Time series Offset50')
+        count = count +1
+        mdFile.new_line(mdFile.new_inline_image(text='Time series NDVI', path=os.path.join(ts_path,satellite_suffix+'-ndvi-time-series.png')))
+        #mdFile.new_paragraph('Figure '+str(count)+': '+'Time series NDVI')
+        mdFile.new_line('')
 
-    count = count +1
-    mdFile.new_line(mdFile.new_inline_image(text='Time series NDVI', path=os.path.join(ts_path,satellite_suffix+'-ndvi-time-series.png')))
-    #mdFile.new_paragraph('Figure '+str(count)+': '+'Time series NDVI')
-    mdFile.new_line('')
+        # STL figures
+        mdFile.new_header(level=1, title='STL decomposition')
+        stl_path = os.path.join(path, 'analysis', 'detrended','STL')
 
-    # STL figures
-    mdFile.new_header(level=1, title='STL decomposition')
-    stl_path = os.path.join(path, 'analysis', 'detrended','STL')
+        count = count +1
+        mdFile.new_line(mdFile.new_inline_image(text='STL Offset50', path=os.path.join(stl_path, satellite_suffix+'_offset50_mean_STL_decomposition.png')))
+        #mdFile.new_paragraph('Figure '+str(count)+': '+'STL Offset50')
 
-    count = count +1
-    mdFile.new_line(mdFile.new_inline_image(text='STL Offset50', path=os.path.join(stl_path, satellite_suffix+'_offset50_mean_STL_decomposition.png')))
-    #mdFile.new_paragraph('Figure '+str(count)+': '+'STL Offset50')
+        count = count +1
+        mdFile.new_line(mdFile.new_inline_image(text='STL NDVI', path=os.path.join(stl_path, satellite_suffix+'_ndvi_mean_STL_decomposition.png')))
+        #mdFile.new_paragraph('Figure '+str(count)+': '+'STL NDVI')
+        mdFile.new_line('')
 
-    count = count +1
-    mdFile.new_line(mdFile.new_inline_image(text='STL NDVI', path=os.path.join(stl_path, satellite_suffix+'_ndvi_mean_STL_decomposition.png')))
-    #mdFile.new_paragraph('Figure '+str(count)+': '+'STL NDVI')
-    mdFile.new_line('')
+        # Early warning figures
+        mdFile.new_header(level=1, title='Early warnings analysis')
+        ews_path = os.path.join(path, 'analysis', 'resiliance','deseasonalised','ewstools')
 
-    # Early warning figures
-    mdFile.new_header(level=1, title='Early warnings analysis')
-    ews_path = os.path.join(path, 'analysis', 'resiliance','deseasonalised','ewstools')
-
-    count = count +1
-    mdFile.new_line(mdFile.new_inline_image(text='EWS Offset50', path=os.path.join(ews_path, satellite_suffix+'-offset50-mean-ews.png')))
-    #mdFile.new_paragraph('Figure '+str(count)+': '+'EWS Offset50')
-    mdFile.new_line()
+        count = count +1
+        mdFile.new_line(mdFile.new_inline_image(text='EWS Offset50', path=os.path.join(ews_path, satellite_suffix+'-offset50-mean-ews.png')))
+        #mdFile.new_paragraph('Figure '+str(count)+': '+'EWS Offset50')
+        mdFile.new_line()
 
 
-    count = count +1
-    mdFile.new_line(
-    mdFile.new_inline_image(text='EWS NDVI', path=os.path.join(ews_path, satellite_suffix+'-ndvi-mean-ews.png')))
-    mdFile.new_line('')
+        count = count +1
+        mdFile.new_line(
+        mdFile.new_inline_image(text='EWS NDVI', path=os.path.join(ews_path, satellite_suffix+'-ndvi-mean-ews.png')))
+        mdFile.new_line('')
 
     mdFile.new_header(level=1, title='RGB images through time')  # style is set 'atx' format by default.
 

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -843,8 +843,8 @@ def preprocess_data(
     print(f'- Saving time series to "{ts_filename}".')
     ts_df.to_csv(ts_filename, index=False)
 
-    # additionally save resampled & detrended time series
-    if detrend:
+    # additionally save resampled & detrended time series (only if time series has more than one date)
+    if detrend and ts_df.shape[0]>1:
         print("- Detrending time series...")
 
         # remove seasonality from sub-image time series

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -42,34 +42,36 @@ def read_json_to_dataframes(data):
 
         rows_list = []
 
-        # loop over time series
-        for date, time_point in coll_results["time-series-data"].items():
+        if "time-series-data" in coll_results.keys():
 
-            # check we have data for this time point
-            if time_point is None or time_point == {} or time_point == []:
+            # loop over time series
+            for date, time_point in coll_results["time-series-data"].items():
 
-                # add Null row if data is missing at this time point
-                rows_list.append({"date": date})
+                # check we have data for this time point
+                if time_point is None or time_point == {} or time_point == []:
 
-            # if we are looking at veg data, loop over space points
-            elif isinstance(list(time_point)[0], dict):
-                for space_point in time_point:
-                    rows_list.append(space_point)
+                    # add Null row if data is missing at this time point
+                    rows_list.append({"date": date})
 
-            # otherwise, just add the row
-            else:
-                # the key of each object in the time series is the date, and data
-                # for this date should be the values. Here we just add the date
-                # as a value to enable us to add the whole row in one go later.
-                time_point["date"] = date
-                rows_list.append(time_point)
+                # if we are looking at veg data, loop over space points
+                elif isinstance(list(time_point)[0], dict):
+                    for space_point in time_point:
+                        rows_list.append(space_point)
 
-        # make a DataFrame and add it to the dict of DataFrames
-        df = pd.DataFrame(rows_list)
-        df = df.drop(columns=["slope", "offset", "mean", "std"], errors="ignore")
-        df = df.sort_values(by="date")
-        assert df.empty == False
-        dfs[collection_name] = df
+                # otherwise, just add the row
+                else:
+                    # the key of each object in the time series is the date, and data
+                    # for this date should be the values. Here we just add the date
+                    # as a value to enable us to add the whole row in one go later.
+                    time_point["date"] = date
+                    rows_list.append(time_point)
+
+            # make a DataFrame and add it to the dict of DataFrames
+            df = pd.DataFrame(rows_list)
+            df = df.drop(columns=["slope", "offset", "mean", "std"], errors="ignore")
+            df = df.sort_values(by="date")
+            assert df.empty == False
+            dfs[collection_name] = df
 
     return dfs
 

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -654,7 +654,7 @@ def detrend_df(df, period="MS"):
         Input with seasonality removed from time series columns.
     """
 
-    # infer lag from period
+    # infer lag from period, we need at least 2 years for diferenciation to work
     if period == "MS":
         lag = 12
     else:
@@ -843,8 +843,9 @@ def preprocess_data(
     print(f'- Saving time series to "{ts_filename}".')
     ts_df.to_csv(ts_filename, index=False)
 
-    # additionally save resampled & detrended time series (only if time series has more than one date)
-    if detrend and ts_df.shape[0]>1:
+    # additionally save resampled & detrended time series
+    # this detrending option (one year seasonality substraction) only works in monthly data that has at least 2 years of data
+    if detrend and ts_df.shape[0]>24 and period=='MS':
         print("- Detrending time series...")
 
         # remove seasonality from sub-image time series

--- a/pyveg/src/plotting.py
+++ b/pyveg/src/plotting.py
@@ -773,6 +773,11 @@ def plot_ews_resiliance(series_name, EWSmetrics_df, Kendalltau_df, dates, output
     def zoom_out(ys):
         ymin = ys.mean() - 2*((ys.mean() - ys).abs().max())
         ymax = ys.mean() + 2*((ys.mean() - ys).abs().max())
+        if np.isnan(ymin):
+            ymin = -1
+        if np.isnan(ymax):
+            ymax = 1
+
         return [ymin, ymax]
 
     def annotate(text, xy=(6    , 70), size=10):


### PR DESCRIPTION
The issues reported on #368  when running the analysis on the data dowloaded on the example configuration are due to the dowloaded having only 1 data time point, therefore no time series analysis is possible. Changes in this PR to fix this:

- [x] Making sure that the time series analysis only happens if the data has at least 3 time points (this analysis doesn't make sense but the analysis script will run).
- [x] Making sure early warning time series analysis only happens if the data has at least 12 time points.
- [x] Reporting only shows the plots produced depending if time series analysis is done.
- [x] Remove detrending option if data doesn't have the minimum 24 month for the 1 year lag detrending option 
- [x] Change configuration example to download data with at least 3 months. 

This branch comes out to PR #393, which should be merged first.
