### PR TITLE
461/separate zenodo

### DIFF
--- a/pyveg/configs/collections.py
+++ b/pyveg/configs/collections.py
@@ -9,8 +9,9 @@ data_collections = {
         "mask_cloud": True,
         "cloudy_pix_frac": 50,
         "cloudy_pix_flag": "CLOUDY_PIXEL_PERCENTAGE",
-        "min_date": "2015-01-01",
-        "max_date": time.strftime("%Y-%m-%d"),
+        "min_date": "2016-01-01",
+        "max_date": "2020-01-01",  # For 2020 paper, look at four whole years
+#        "max_date": time.strftime("%Y-%m-%d"),
         "time_per_point": "1m",
     },
     "Landsat8": {
@@ -59,7 +60,8 @@ data_collections = {
         "precipitation_band": ["total_precipitation"],
         "temperature_band": ["mean_2m_air_temperature"],
         "min_date": "1986-01-01",
-        "max_date": time.strftime("%Y-%m-%d"),
+        "max_date": "2020-01-01",
+        #        "max_date": time.strftime("%Y-%m-%d"),
         "time_per_point": "1m",
     },
     "ERA5_daily": {

--- a/pyveg/scripts/upload_to_zenodo.py
+++ b/pyveg/scripts/upload_to_zenodo.py
@@ -52,7 +52,7 @@ def upload_results_summary(json_location,
     """
     Upload the results summary json from running pyveg pipeline to download and process data from GEE.
     """
-    deposition_id = get_deposition_id(use_test_api)
+    deposition_id = get_deposition_id("json", test=use_test_api)
 
     # read in the json
     results_summary = read_results_summary(json_location, input_location_type=json_location_type)
@@ -74,7 +74,7 @@ def upload_summary_stats(csv_filepath, use_test_api):
     Typically called by the analyse_gee_data script, upload the
     results summary csv file.
     """
-    deposition_id = get_deposition_id(use_test_api)
+    deposition_id = get_deposition_id("csv", use_test_api)
     uploaded_ok = upload_file(csv_filepath, deposition_id, use_test_api)
     return uploaded_ok
 

--- a/pyveg/src/zenodo_utils.py
+++ b/pyveg/src/zenodo_utils.py
@@ -53,16 +53,20 @@ def get_base_url_and_token(test=False):
     return base_url, token
 
 
-def get_deposition_id(test=False):
+def get_deposition_id(json_or_csv="json", test=False):
     """
     If we have previously created a deposition, we hopefully stored its ID in
     the zenodo_config.py file.
     """
     if test:
-        return config.test_api_credentials["deposition_id"]
-    else:
-        return config.prod_api_credentials["deposition_id"]
+        credentials = config.test_api_credentials
 
+    else:
+        credentials =  config.prod_api_credentials
+    if json_or_csv == "json":
+        return credentials["deposition_id_summary_json"]
+    else:
+        return credentials["deposition_id_ts_csv"]
 
 
 def list_depositions(test=False):
@@ -184,13 +188,15 @@ def upload_file(filename, deposition_id, test=False):
         return True
 
 
-def list_files(deposition_id, test=False):
+def list_files(deposition_id, json_or_csv="json", test=False):
     """
     List all the files in a deposition.
 
     Parameters
     ==========
     deposition_id: int, ID of the deposition on which to list files
+    json_or_csv: str, if 'json', list the deposition containing the results_summary.json
+                 otherwise list the one containing ts_summary_stats.csv
     test: bool, True if using the sandbox API, False otherwise
 
     Returns
@@ -199,7 +205,7 @@ def list_files(deposition_id, test=False):
     """
 
     base_url, api_token = get_base_url_and_token(test)
-    deposition_id = get_deposition_id(test)
+    deposition_id = get_deposition_id(json_or_csv, test=test)
     r = requests.get("{}/deposit/depositions/{}/files".format(base_url, deposition_id),
                      params={"access_token": api_token})
     if r.status_code != 200:
@@ -236,7 +242,7 @@ def download_file(filename, deposition_id, destination_path=".", test=False):
     return destination
 
 
-def upload_standard_metadata(deposition_id, test=False):
+def upload_standard_metadata(deposition_id, json_or_csv="json", test=False):
     """
     Upload the metadata dict defined in zenodo_config.py to the
     specified deposition ID.Kcontaining metadata with the format:
@@ -244,13 +250,18 @@ def upload_standard_metadata(deposition_id, test=False):
     Parameters:
     ==========
     deposition_id: int, ID of the deposition to which to upload
+    json_or_csv: str, can be either 'json' to upload the metadata for `results_summary.json`
+                   or `csv` to upload the metadata for `ts_summary_stats.csv`
     test: if True, use the sandbox API, if False use the production one.
 
     Returns
     =======
     r: dict, JSON response from the API.
     """
-    metadata_dict = config.metadata_dict
+    if json_or_csv == "json":
+        metadata_dict = config.metadata_dict_summary_json
+    else:
+        metadata_dict = config.metadata_dict_ts_csv
     base_url, api_token = get_base_url_and_token(test)
     r = requests.put("{}/deposit/depositions/{}".format(base_url, deposition_id),
                      params={"access_token": api_token},
@@ -423,7 +434,7 @@ def download_results_summary_by_coord_id(coords_id, destination_path=None, depos
     if not re.search('[\d]{2}', coords_id):
         raise RuntimeError("coords_id should be a 2-digit string")
     if not deposition_id:
-        deposition_id = get_deposition_id(test)
+        deposition_id = get_deposition_id("json", test=test)
     if not destination_path:
         destination_path = tempfile.TemporaryDirectory().name
     elif not os.path.exists(destination_path):


### PR DESCRIPTION
* Separate zenodo depositions for results_summary json and ts_summary_stats csv - update `zenodo_utils.py` and `upload_to_zenodo.py` to reflect this.

Closes #461 