### PR TITLE
Feature/455 add cb summary stats

### DIFF
--- a/notebooks/tutorials/tutorial_download_and_process_gee_images.ipynb
+++ b/notebooks/tutorials/tutorial_download_and_process_gee_images.ipynb
@@ -15,9 +15,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p>To authorize access needed by Earth Engine, open the following\n",
+       "        URL in a web browser and follow the instructions:</p>\n",
+       "        <p><a href=https://accounts.google.com/o/oauth2/auth?client_id=517222506229-vsmmajv00ul0bs7p89v5m89qs8eb9359.apps.googleusercontent.com&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fearthengine+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&code_challenge=YCMlsG4L94YlxQ56qWJp_WZI7A5gEyR3ItZuePQaqDo&code_challenge_method=S256>https://accounts.google.com/o/oauth2/auth?client_id=517222506229-vsmmajv00ul0bs7p89v5m89qs8eb9359.apps.googleusercontent.com&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fearthengine+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&code_challenge=YCMlsG4L94YlxQ56qWJp_WZI7A5gEyR3ItZuePQaqDo&code_challenge_method=S256</a></p>\n",
+       "        <p>The authorization workflow will generate a code, which you\n",
+       "        should paste in the box below</p>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enter verification code: 4/4gHY1mbA7s9uO-zuYK0K7y5Q-BdxFj5xfLOMEebXFBBueb3ZsZgiEeU\n",
+      "\n",
+      "Successfully saved authorization token.\n"
+     ]
+    }
+   ],
    "source": [
     "import ee\n",
     "ee.Authenticate()"
@@ -57,9 +84,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: pyveg_generate_config [-h] [--coords_id COORDS_ID]\r\n",
+      "                             [--configs_dir CONFIGS_DIR]\r\n",
+      "                             [--collection_name COLLECTION_NAME]\r\n",
+      "                             [--output_dir OUTPUT_DIR] [--test_mode]\r\n",
+      "                             [--latitude LATITUDE] [--longitude LONGITUDE]\r\n",
+      "                             [--country COUNTRY] [--start_date START_DATE]\r\n",
+      "                             [--end_date END_DATE]\r\n",
+      "                             [--time_per_point TIME_PER_POINT]\r\n",
+      "                             [--region_size REGION_SIZE]\r\n",
+      "                             [--pattern_type PATTERN_TYPE]\r\n",
+      "                             [--run_mode RUN_MODE] [--n_threads N_THREADS]\r\n",
+      "\r\n",
+      "Create a config file for running pyveg_pipeline. If run with no arguments\r\n",
+      "(recommended), the user will be prompted for each parameter, or can choose a\r\n",
+      "default value.\r\n",
+      "\r\n",
+      "optional arguments:\r\n",
+      "  -h, --help            show this help message and exit\r\n",
+      "  --coords_id COORDS_ID\r\n",
+      "                        (optional) ID of location in coordinates.py\r\n",
+      "  --configs_dir CONFIGS_DIR\r\n",
+      "                        path to directory containing config files\r\n",
+      "  --collection_name COLLECTION_NAME\r\n",
+      "                        collection name (e.g. 'Sentinel2')\r\n",
+      "  --output_dir OUTPUT_DIR\r\n",
+      "                        Directory for local output data\r\n",
+      "  --test_mode           Run in test mode, over fewer months and with fewer\r\n",
+      "                        sub-images\r\n",
+      "  --latitude LATITUDE   latitude in degrees N\r\n",
+      "  --longitude LONGITUDE\r\n",
+      "                        longitude in degrees E\r\n",
+      "  --country COUNTRY     Country of location\r\n",
+      "  --start_date START_DATE\r\n",
+      "                        start date, format YYYY-MM-DD\r\n",
+      "  --end_date END_DATE   end date, format YYYY-MM-DD\r\n",
+      "  --time_per_point TIME_PER_POINT\r\n",
+      "                        frequency of image, e.g. '1m', '1w'\r\n",
+      "  --region_size REGION_SIZE\r\n",
+      "                        Size of region to download, in degrees lat/long\r\n",
+      "  --pattern_type PATTERN_TYPE\r\n",
+      "                        Type of patterned vegetation, e.g. 'spots',\r\n",
+      "                        'labyrinths'\r\n",
+      "  --run_mode RUN_MODE   'local' for running on local machine, 'azure' for\r\n",
+      "                        running some time-consuming parts (i.e. vegetation\r\n",
+      "                        image processing) on Azure batch\r\n",
+      "  --n_threads N_THREADS\r\n",
+      "                        How many threads (cores) to parallelize some\r\n",
+      "                        processing functions over\r\n"
+     ]
+    }
+   ],
    "source": [
     "!pyveg_generate_config --help"
    ]
@@ -74,11 +156,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "    output_location ./Sentinel2-11.58N-27.94E-Sudan\r\n",
+      "    collection: Sentinel2\r\n",
+      "    latitude: 11.58\r\n",
+      "    longitude: 27.94\r\n",
+      "    country: Sudan\r\n",
+      "    pattern_type: unknown\r\n",
+      "    start_date: 2019-01-01\r\n",
+      "    end_date: 2019-04-01\r\n",
+      "    time_per_point: 1m\r\n",
+      "    region_size: 0.08\r\n",
+      "    run_mode: local\r\n",
+      "    n_threads: 2\r\n",
+      "    \r\n",
+      "================================\r\n",
+      "Wrote file \r\n",
+      "  ../../pyveg/configs/testconfig_Sentinel2_11.58N_27.94E_Sudan_0.08_unknown_2019-01-01_2019-04-01_1m_local.py\r\n",
+      "We recommend that you add and commit this to your version control repository.\r\n",
+      "================================\r\n",
+      "\r\n",
+      "To run pyveg using this configuration, do:\r\n",
+      "\r\n",
+      "pyveg_run_pipeline --config_file ../../pyveg/configs/testconfig_Sentinel2_11.58N_27.94E_Sudan_0.08_unknown_2019-01-01_2019-04-01_1m_local.py\r\n",
+      "\r\n",
+      "\r\n"
+     ]
+    }
+   ],
    "source": [
-    "!pyveg_generate_config --configs_dir ../../pyveg/configs --collection_name Sentinel2 --output_dir ./ --test_mode --latitude 11.58 --longitude 27.94 --country Sudan --start_date 2019-01-01 --end_date 2019-04-01 --time_per_point 1m --run_mode local --n_threads 2"
+    "!pyveg_generate_config --configs_dir ../../pyveg/configs --collection_name Sentinel2 --output_dir ./ --test_mode --latitude 11.58 --longitude 27.94 --country Sudan --start_date 2019-01-01 --end_date 2019-04-01 --time_per_point 1m --run_mode local --n_threads 2   --region_size 0.08 --pattern_type 'unknown'"
    ]
   },
   {
@@ -90,9 +204,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "    azure_config.py not found - this is needed for using Azure storage or batch.\n",
+      "    Copy pyveg/azure_config_template.py to pyveg/azure_config.py then input your\n",
+      "    own values for Azure Storage account name and Access key, then redo `pip install .`\n",
+      "    \n",
+      "\n",
+      "    azure_config.py not found - this is needed for using Azure storage or batch.\n",
+      "    Copy pyveg/azure_config_template.py to pyveg/azure_config.py then input your\n",
+      "    own values for Azure Storage account name and Access key, then redo `pip install .`\n",
+      "    \n",
+      "Traceback (most recent call last):\n",
+      "  File \"/anaconda3/envs/veg/bin/pyveg_run_pipeline\", line 8, in <module>\n",
+      "    sys.exit(main())\n",
+      "  File \"/anaconda3/envs/veg/lib/python3.7/site-packages/pyveg/scripts/run_pyveg_pipeline.py\", line 147, in main\n",
+      "    pipeline = build_pipeline(args.config_file, args.from_cache)\n",
+      "  File \"/anaconda3/envs/veg/lib/python3.7/site-packages/pyveg/scripts/run_pyveg_pipeline.py\", line 41, in build_pipeline\n",
+      "    raise FileNotFoundError(\"Unable to find config file {}\".format(config_file))\n",
+      "FileNotFoundError: Unable to find config file ../../pyveg/configs/testconfig_Sentinel2_11.58N_27.94E_Sudan_2019-01-01_2019-04-01_1m_local.py\n"
+     ]
+    }
+   ],
    "source": [
     "!pyveg_run_pipeline --config_file ../../pyveg/configs/testconfig_Sentinel2_11.58N_27.94E_Sudan_2019-01-01_2019-04-01_1m_local.py\n",
     "\n"
@@ -126,16 +265,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "    azure_config.py not found - this is needed for using Azure storage or batch.\n",
+      "    Copy pyveg/azure_config_template.py to pyveg/azure_config.py then input your\n",
+      "    own values for Azure Storage account name and Access key, then redo `pip install .`\n",
+      "    \n",
+      "\n",
+      "    azure_config.py not found - this is needed for using Azure storage or batch.\n",
+      "    Copy pyveg/azure_config_template.py to pyveg/azure_config.py then input your\n",
+      "    own values for Azure Storage account name and Access key, then redo `pip install .`\n",
+      "    \n"
+     ]
+    }
+   ],
    "source": [
     "from pyveg.src.download_modules import VegetationDownloader"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,9 +308,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'collection_name': 'COPERNICUS/S2', 'data_type': 'vegetation', 'RGB_bands': ['B4', 'B3', 'B2'], 'NIR_band': 'B8', 'mask_cloud': True, 'cloudy_pix_frac': 50, 'cloudy_pix_flag': 'CLOUDY_PIXEL_PERCENTAGE', 'min_date': '2016-01-01', 'max_date': '2020-01-01', 'time_per_point': '1m'}\n"
+     ]
+    }
+   ],
    "source": [
     "from pyveg.configs.collections import data_collections\n",
     "s2_config = data_collections[\"Sentinel2\"]\n",
@@ -170,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,9 +391,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:20:24,909 [INFO] Sentinel2_download: setting collection_name to COPERNICUS/S2\n",
+      "2020-09-28 11:20:24,913 [INFO] Sentinel2_download: setting data_type to vegetation\n",
+      "2020-09-28 11:20:24,914 [INFO] Sentinel2_download: setting RGB_bands to ['B4', 'B3', 'B2']\n",
+      "2020-09-28 11:20:24,915 [INFO] Sentinel2_download: setting NIR_band to B8\n",
+      "2020-09-28 11:20:24,916 [INFO] Sentinel2_download: setting mask_cloud to True\n",
+      "2020-09-28 11:20:24,917 [INFO] Sentinel2_download: setting cloudy_pix_frac to 50\n",
+      "2020-09-28 11:20:24,918 [INFO] Sentinel2_download: setting cloudy_pix_flag to CLOUDY_PIXEL_PERCENTAGE\n",
+      "2020-09-28 11:20:24,919 [INFO] Sentinel2_download: setting min_date to 2016-01-01\n",
+      "2020-09-28 11:20:24,919 [INFO] Sentinel2_download: setting max_date to 2020-01-01\n",
+      "2020-09-28 11:20:24,920 [INFO] Sentinel2_download: setting time_per_point to 1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        [Module]: Sentinel2_download \n",
+      "        =======================\n",
+      "        depends_on: []\n",
+      "        is_configured: True\n",
+      "        is_finished: False\n",
+      "        run_status: {'succeeded': 0, 'failed': 0, 'incomplete': 0}\n",
+      "        collection_name: COPERNICUS/S2\n",
+      "        data_type: vegetation\n",
+      "        RGB_bands: ['B4', 'B3', 'B2']\n",
+      "        NIR_band: B8\n",
+      "        mask_cloud: True\n",
+      "        cloudy_pix_frac: 50\n",
+      "        cloudy_pix_flag: CLOUDY_PIXEL_PERCENTAGE\n",
+      "        min_date: 2016-01-01\n",
+      "        max_date: 2020-01-01\n",
+      "        time_per_point: 1m\n",
+      "        coords: [28.37, 11.12]\n",
+      "        date_range: ['2018-06-01', '2018-07-01']\n",
+      "        output_location: /tmp/gee_veg_download_example\n",
+      "        output_location_type: local\n",
+      "        region_size: 0.08\n",
+      "        scale: 10\n",
+      "        replace_existing_files: False\n",
+      "        num_files_per_point: 4\n",
+      "        =======================\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# we could go through all the key,value pairs in the s2_config dict setting them all\n",
     "# individually, but lets do them all at once\n",
@@ -251,9 +465,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:20:56,293 [INFO] Sentinel2_download: Will download to /tmp/gee_veg_download_example/2018-06-16/RAW\n",
+      "INFO:pyveg_logger:Sentinel2_download: Will download to /tmp/gee_veg_download_example/2018-06-16/RAW\n",
+      "2020-09-28 11:20:56,320 [INFO] Sentinel2_download: download succeeded for date range ['2018-06-01', '2018-07-01']\n",
+      "INFO:pyveg_logger:Sentinel2_download: download succeeded for date range ['2018-06-01', '2018-07-01']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'succeeded': 1, 'failed': 0, 'incomplete': 0}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "vd.run()"
    ]
@@ -267,9 +502,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['download.NDVI.tif', 'download.B4.tif', 'download.B3.tif', 'download.B2.tif']"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "os.listdir(os.path.join(output_veg_location,\"2018-06-16\",\"RAW\"))"
    ]
@@ -285,9 +531,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:20:56,677 [INFO] Sentinel2_img_processor: setting collection_name to COPERNICUS/S2\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting collection_name to COPERNICUS/S2\n",
+      "2020-09-28 11:20:56,678 [INFO] Sentinel2_img_processor: setting data_type to vegetation\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting data_type to vegetation\n",
+      "2020-09-28 11:20:56,680 [INFO] Sentinel2_img_processor: setting RGB_bands to ['B4', 'B3', 'B2']\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting RGB_bands to ['B4', 'B3', 'B2']\n",
+      "2020-09-28 11:20:56,681 [INFO] Sentinel2_img_processor: setting NIR_band to B8\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting NIR_band to B8\n",
+      "2020-09-28 11:20:56,683 [INFO] Sentinel2_img_processor: setting mask_cloud to True\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting mask_cloud to True\n",
+      "2020-09-28 11:20:56,684 [INFO] Sentinel2_img_processor: setting cloudy_pix_frac to 50\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting cloudy_pix_frac to 50\n",
+      "2020-09-28 11:20:56,686 [INFO] Sentinel2_img_processor: setting cloudy_pix_flag to CLOUDY_PIXEL_PERCENTAGE\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting cloudy_pix_flag to CLOUDY_PIXEL_PERCENTAGE\n",
+      "2020-09-28 11:20:56,687 [INFO] Sentinel2_img_processor: setting min_date to 2016-01-01\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting min_date to 2016-01-01\n",
+      "2020-09-28 11:20:56,689 [INFO] Sentinel2_img_processor: setting max_date to 2020-01-01\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting max_date to 2020-01-01\n",
+      "2020-09-28 11:20:56,690 [INFO] Sentinel2_img_processor: setting time_per_point to 1m\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: setting time_per_point to 1m\n"
+     ]
+    }
+   ],
    "source": [
     "from pyveg.src.processor_modules import VegetationImageProcessor\n",
     "vip = VegetationImageProcessor(\"Sentinel2_img_processor\")\n",
@@ -304,9 +577,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        [Module]: Sentinel2_img_processor \n",
+      "        =======================\n",
+      "        depends_on: []\n",
+      "        is_configured: True\n",
+      "        is_finished: False\n",
+      "        run_status: {'succeeded': 0, 'failed': 0, 'incomplete': 0}\n",
+      "        collection_name: COPERNICUS/S2\n",
+      "        data_type: vegetation\n",
+      "        RGB_bands: ['B4', 'B3', 'B2']\n",
+      "        NIR_band: B8\n",
+      "        mask_cloud: True\n",
+      "        cloudy_pix_frac: 50\n",
+      "        cloudy_pix_flag: CLOUDY_PIXEL_PERCENTAGE\n",
+      "        min_date: 2016-01-01\n",
+      "        max_date: 2020-01-01\n",
+      "        time_per_point: 1m\n",
+      "        coords: [28.37, 11.12]\n",
+      "        input_location: /tmp/gee_veg_download_example\n",
+      "        output_location: /tmp/gee_veg_download_example\n",
+      "        replace_existing_files: False\n",
+      "        num_files_per_point: 3\n",
+      "        input_location_type: local\n",
+      "        output_location_type: local\n",
+      "        dates_to_process: []\n",
+      "        run_mode: local\n",
+      "        n_batch_tasks: -1\n",
+      "        batch_task_dict: {}\n",
+      "        timeout: 30\n",
+      "        region_size: 0.08\n",
+      "        split_RGB_images: True\n",
+      "        input_location_subdirs: ['RAW']\n",
+      "        output_location_subdirs: ['PROCESSED']\n",
+      "        =======================\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "vip.input_location = vd.output_location\n",
     "vip.output_location = vd.output_location\n",
@@ -316,9 +631,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:20:56,702 [INFO] Sentinel2_img_processor: Running local\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: Running local\n",
+      "2020-09-28 11:20:56,706 [INFO] Sentinel2_img_processor processing files in /tmp/gee_veg_download_example/2018-06-16/RAW\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor processing files in /tmp/gee_veg_download_example/2018-06-16/RAW\n",
+      "2020-09-28 11:20:56,708 [INFO] ['download.NDVI.tif', 'download.B4.tif', 'download.B3.tif', 'download.B2.tif']\n",
+      "INFO:pyveg_logger:['download.NDVI.tif', 'download.B4.tif', 'download.B3.tif', 'download.B2.tif']\n",
+      "2020-09-28 11:20:56,709 [INFO] Sentinel2_img_processor: Saving RGB image for 2018-06-16 28.37_11.12\n",
+      "INFO:pyveg_logger:Sentinel2_img_processor: Saving RGB image for 2018-06-16 28.37_11.12\n",
+      "2020-09-28 11:21:02,051 [INFO] Will save image to /tmp/gee_veg_download_example/2018-06-16/PROCESSED / 2018-06-16_28.37_11.12_RGB.png\n",
+      "INFO:pyveg_logger:Will save image to /tmp/gee_veg_download_example/2018-06-16/PROCESSED / 2018-06-16_28.37_11.12_RGB.png\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved image '/tmp/gee_veg_download_example/2018-06-16/PROCESSED/2018-06-16_28.37_11.12_RGB.png'\n",
+      "Saved image '/tmp/gee_veg_download_example/2018-06-16/PROCESSED/2018-06-16_28.37_11.12_NDVI.png'\n",
+      "Saved image '/tmp/gee_veg_download_example/2018-06-16/PROCESSED/2018-06-16_28.37_11.12_BWNDVI.png'\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'succeeded': 1, 'failed': 0, 'incomplete': 0}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "vip.run()"
    ]
@@ -332,9 +683,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['2018-06-16_28.37_11.12_NDVI.png',\n",
+       " '2018-06-16_28.37_11.12_BWNDVI.png',\n",
+       " '2018-06-16_28.37_11.12_RGB.png']"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "os.listdir(os.path.join(output_veg_location,\"2018-06-16\",\"PROCESSED\"))"
    ]
@@ -350,9 +714,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:21:14,402 [INFO] Sentinel2_ncc: setting collection_name to COPERNICUS/S2\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting collection_name to COPERNICUS/S2\n",
+      "2020-09-28 11:21:14,404 [INFO] Sentinel2_ncc: setting data_type to vegetation\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting data_type to vegetation\n",
+      "2020-09-28 11:21:14,405 [INFO] Sentinel2_ncc: setting RGB_bands to ['B4', 'B3', 'B2']\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting RGB_bands to ['B4', 'B3', 'B2']\n",
+      "2020-09-28 11:21:14,407 [INFO] Sentinel2_ncc: setting NIR_band to B8\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting NIR_band to B8\n",
+      "2020-09-28 11:21:14,408 [INFO] Sentinel2_ncc: setting mask_cloud to True\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting mask_cloud to True\n",
+      "2020-09-28 11:21:14,410 [INFO] Sentinel2_ncc: setting cloudy_pix_frac to 50\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting cloudy_pix_frac to 50\n",
+      "2020-09-28 11:21:14,411 [INFO] Sentinel2_ncc: setting cloudy_pix_flag to CLOUDY_PIXEL_PERCENTAGE\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting cloudy_pix_flag to CLOUDY_PIXEL_PERCENTAGE\n",
+      "2020-09-28 11:21:14,412 [INFO] Sentinel2_ncc: setting min_date to 2016-01-01\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting min_date to 2016-01-01\n",
+      "2020-09-28 11:21:14,414 [INFO] Sentinel2_ncc: setting max_date to 2020-01-01\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting max_date to 2020-01-01\n",
+      "2020-09-28 11:21:14,416 [INFO] Sentinel2_ncc: setting time_per_point to 1m\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: setting time_per_point to 1m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        [Module]: Sentinel2_ncc \n",
+      "        =======================\n",
+      "        depends_on: []\n",
+      "        is_configured: True\n",
+      "        is_finished: False\n",
+      "        run_status: {'succeeded': 0, 'failed': 0, 'incomplete': 0}\n",
+      "        collection_name: COPERNICUS/S2\n",
+      "        data_type: vegetation\n",
+      "        RGB_bands: ['B4', 'B3', 'B2']\n",
+      "        NIR_band: B8\n",
+      "        mask_cloud: True\n",
+      "        cloudy_pix_frac: 50\n",
+      "        cloudy_pix_flag: CLOUDY_PIXEL_PERCENTAGE\n",
+      "        min_date: 2016-01-01\n",
+      "        max_date: 2020-01-01\n",
+      "        time_per_point: 1m\n",
+      "        input_location: /tmp/gee_veg_download_example\n",
+      "        output_location: /tmp/gee_veg_download_example\n",
+      "        replace_existing_files: False\n",
+      "        num_files_per_point: 1\n",
+      "        input_location_type: local\n",
+      "        output_location_type: local\n",
+      "        dates_to_process: []\n",
+      "        run_mode: local\n",
+      "        n_batch_tasks: -1\n",
+      "        batch_task_dict: {}\n",
+      "        timeout: 30\n",
+      "        n_threads: 4\n",
+      "        n_sub_images: -1\n",
+      "        input_location_subdirs: ['SPLIT']\n",
+      "        output_location_subdirs: ['JSON', 'NC']\n",
+      "        =======================\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from pyveg.src.processor_modules import NetworkCentralityCalculator\n",
     "ncc = NetworkCentralityCalculator(\"Sentinel2_ncc\")\n",
@@ -372,7 +803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,9 +812,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:21:14,428 [INFO] Sentinel2_ncc: Running local\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: Running local\n",
+      "2020-09-28 11:21:14,434 [INFO] Sentinel2_ncc: processing 2018-06-16\n",
+      "INFO:pyveg_logger:Sentinel2_ncc: processing 2018-06-16\n",
+      "2020-09-28 11:21:14,813 [INFO] Sentinel2_ncc found 289 sub-images\n",
+      "INFO:pyveg_logger:Sentinel2_ncc found 289 sub-images\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processed 10 sub-images...\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:21:25,138 [INFO] \n",
+      " Consolidating json from all subimages\n",
+      "INFO:pyveg_logger:\n",
+      " Consolidating json from all subimages\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'succeeded': 1, 'failed': 0, 'incomplete': 0}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ncc.run()"
    ]
@@ -397,16 +868,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['network_centralities.json']"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "os.listdir(os.path.join(output_veg_location,\"2018-06-16\",\"JSON\",\"NC\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,9 +905,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['slope', 'offset', 'offset50', 'mean', 'std', 'feature_vec', 'date', 'latitude', 'longitude'])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "j[0].keys()"
    ]
@@ -441,7 +934,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,9 +945,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'collection_name': 'ECMWF/ERA5/MONTHLY',\n",
+       " 'data_type': 'weather',\n",
+       " 'precipitation_band': ['total_precipitation'],\n",
+       " 'temperature_band': ['mean_2m_air_temperature'],\n",
+       " 'min_date': '1986-01-01',\n",
+       " 'max_date': '2020-01-01',\n",
+       " 'time_per_point': '1m'}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "era_config = data_collections[\"ERA5\"]\n",
     "era_config"
@@ -469,9 +979,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:21:25,205 [INFO] era5_sequence: setting collection_name to ECMWF/ERA5/MONTHLY\n",
+      "INFO:pyveg_logger:era5_sequence: setting collection_name to ECMWF/ERA5/MONTHLY\n",
+      "2020-09-28 11:21:25,207 [INFO] era5_sequence: setting data_type to weather\n",
+      "INFO:pyveg_logger:era5_sequence: setting data_type to weather\n",
+      "2020-09-28 11:21:25,209 [INFO] era5_sequence: setting precipitation_band to ['total_precipitation']\n",
+      "INFO:pyveg_logger:era5_sequence: setting precipitation_band to ['total_precipitation']\n",
+      "2020-09-28 11:21:25,211 [INFO] era5_sequence: setting temperature_band to ['mean_2m_air_temperature']\n",
+      "INFO:pyveg_logger:era5_sequence: setting temperature_band to ['mean_2m_air_temperature']\n",
+      "2020-09-28 11:21:25,213 [INFO] era5_sequence: setting min_date to 1986-01-01\n",
+      "INFO:pyveg_logger:era5_sequence: setting min_date to 1986-01-01\n",
+      "2020-09-28 11:21:25,215 [INFO] era5_sequence: setting max_date to 2020-01-01\n",
+      "INFO:pyveg_logger:era5_sequence: setting max_date to 2020-01-01\n",
+      "2020-09-28 11:21:25,217 [INFO] era5_sequence: setting time_per_point to 1m\n",
+      "INFO:pyveg_logger:era5_sequence: setting time_per_point to 1m\n"
+     ]
+    }
+   ],
    "source": [
     "s=Sequence(\"era5_sequence\")\n",
     "s.date_range = date_range\n",
@@ -488,9 +1019,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "    [Sequence]: era5_sequence \n",
+      "    =======================\n",
+      "    depends_on: []\n",
+      "    output_location: gee_28.37_11.12_era5_sequence\n",
+      "    output_location_type: local\n",
+      "    is_configured: True\n",
+      "    is_finished: False\n",
+      "    run_status: {}\n",
+      "    date_range: ['2018-06-01', '2018-07-01']\n",
+      "    coords: [28.37, 11.12]\n",
+      "    collection_name: ECMWF/ERA5/MONTHLY\n",
+      "    data_type: weather\n",
+      "    precipitation_band: ['total_precipitation']\n",
+      "    temperature_band: ['mean_2m_air_temperature']\n",
+      "    min_date: 1986-01-01\n",
+      "    max_date: 2020-01-01\n",
+      "    time_per_point: 1m\n",
+      "\n",
+      "    ------- Modules ----------\n",
+      "\n",
+      "        [Module]: era5_sequence_WeatherDownloader \n",
+      "        =======================\n",
+      "        depends_on: []\n",
+      "        is_configured: True\n",
+      "        is_finished: False\n",
+      "        run_status: {'succeeded': 0, 'failed': 0, 'incomplete': 0}\n",
+      "        output_location: gee_28.37_11.12_era5_sequence\n",
+      "        output_location_type: local\n",
+      "        coords: [28.37, 11.12]\n",
+      "        date_range: ['2018-06-01', '2018-07-01']\n",
+      "        region_size: 0.08\n",
+      "        scale: 10\n",
+      "        replace_existing_files: False\n",
+      "        num_files_per_point: 2\n",
+      "        collection_name: ECMWF/ERA5/MONTHLY\n",
+      "        temperature_band: ['mean_2m_air_temperature']\n",
+      "        precipitation_band: ['total_precipitation']\n",
+      "        time_per_point: 1m\n",
+      "        =======================\n",
+      "\n",
+      "        [Module]: era5_sequence_WeatherImageToJSON \n",
+      "        =======================\n",
+      "        depends_on: ['era5_sequence_WeatherDownloader']\n",
+      "        is_configured: True\n",
+      "        is_finished: False\n",
+      "        run_status: {'succeeded': 0, 'failed': 0, 'incomplete': 0}\n",
+      "        output_location: gee_28.37_11.12_era5_sequence\n",
+      "        output_location_type: local\n",
+      "        input_location: gee_28.37_11.12_era5_sequence\n",
+      "        input_location_type: local\n",
+      "        coords: [28.37, 11.12]\n",
+      "        date_range: ['2018-06-01', '2018-07-01']\n",
+      "        replace_existing_files: False\n",
+      "        num_files_per_point: -1\n",
+      "        dates_to_process: []\n",
+      "        run_mode: local\n",
+      "        n_batch_tasks: -1\n",
+      "        batch_task_dict: {}\n",
+      "        timeout: 30\n",
+      "        input_location_subdirs: ['RAW']\n",
+      "        output_location_subdirs: ['JSON', 'WEATHER']\n",
+      "        =======================\n",
+      "\n",
+      "    =======================\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "s += WeatherDownloader()\n",
     "s += WeatherImageToJSON()\n",
@@ -507,9 +1112,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "    [Sequence]: era5_sequence \n",
+      "    =======================\n",
+      "    depends_on: []\n",
+      "    output_location: /tmp/gee_weather_download_example\n",
+      "    output_location_type: local\n",
+      "    is_configured: True\n",
+      "    is_finished: False\n",
+      "    run_status: {}\n",
+      "    date_range: ['2018-06-01', '2018-07-01']\n",
+      "    coords: [28.37, 11.12]\n",
+      "    collection_name: ECMWF/ERA5/MONTHLY\n",
+      "    data_type: weather\n",
+      "    precipitation_band: ['total_precipitation']\n",
+      "    temperature_band: ['mean_2m_air_temperature']\n",
+      "    min_date: 1986-01-01\n",
+      "    max_date: 2020-01-01\n",
+      "    time_per_point: 1m\n",
+      "\n",
+      "    ------- Modules ----------\n",
+      "\n",
+      "        [Module]: era5_sequence_WeatherDownloader \n",
+      "        =======================\n",
+      "        depends_on: []\n",
+      "        is_configured: True\n",
+      "        is_finished: False\n",
+      "        run_status: {'succeeded': 0, 'failed': 0, 'incomplete': 0}\n",
+      "        output_location: /tmp/gee_weather_download_example\n",
+      "        output_location_type: local\n",
+      "        coords: [28.37, 11.12]\n",
+      "        date_range: ['2018-06-01', '2018-07-01']\n",
+      "        region_size: 0.08\n",
+      "        scale: 10\n",
+      "        replace_existing_files: False\n",
+      "        num_files_per_point: 2\n",
+      "        collection_name: ECMWF/ERA5/MONTHLY\n",
+      "        temperature_band: ['mean_2m_air_temperature']\n",
+      "        precipitation_band: ['total_precipitation']\n",
+      "        time_per_point: 1m\n",
+      "        =======================\n",
+      "\n",
+      "        [Module]: era5_sequence_WeatherImageToJSON \n",
+      "        =======================\n",
+      "        depends_on: ['era5_sequence_WeatherDownloader', 'era5_sequence_WeatherDownloader']\n",
+      "        is_configured: True\n",
+      "        is_finished: False\n",
+      "        run_status: {'succeeded': 0, 'failed': 0, 'incomplete': 0}\n",
+      "        output_location: /tmp/gee_weather_download_example\n",
+      "        output_location_type: local\n",
+      "        input_location: /tmp/gee_weather_download_example\n",
+      "        input_location_type: local\n",
+      "        coords: [28.37, 11.12]\n",
+      "        date_range: ['2018-06-01', '2018-07-01']\n",
+      "        replace_existing_files: False\n",
+      "        num_files_per_point: -1\n",
+      "        dates_to_process: []\n",
+      "        run_mode: local\n",
+      "        n_batch_tasks: -1\n",
+      "        batch_task_dict: {}\n",
+      "        timeout: 30\n",
+      "        input_location_subdirs: ['RAW']\n",
+      "        output_location_subdirs: ['JSON', 'WEATHER']\n",
+      "        =======================\n",
+      "\n",
+      "    =======================\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "output_weather_location = os.path.join(TMPDIR, \"gee_weather_download_example\")\n",
     "s.output_location = output_weather_location\n",
@@ -527,9 +1206,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2020-09-28 11:21:28,893 [INFO] era5_sequence_WeatherDownloader: Will download to /tmp/gee_weather_download_example/2018-06-16/RAW\n",
+      "INFO:pyveg_logger:era5_sequence_WeatherDownloader: Will download to /tmp/gee_weather_download_example/2018-06-16/RAW\n",
+      "2020-09-28 11:21:28,900 [INFO] era5_sequence_WeatherDownloader: download succeeded for date range ['2018-06-01', '2018-07-01']\n",
+      "INFO:pyveg_logger:era5_sequence_WeatherDownloader: download succeeded for date range ['2018-06-01', '2018-07-01']\n",
+      "2020-09-28 11:21:28,901 [INFO] era5_sequence_WeatherImageToJSON: Running local\n",
+      "INFO:pyveg_logger:era5_sequence_WeatherImageToJSON: Running local\n",
+      "2020-09-28 11:21:28,904 [INFO] era5_sequence_WeatherImageToJSON: Processing date 2018-06-16\n",
+      "INFO:pyveg_logger:era5_sequence_WeatherImageToJSON: Processing date 2018-06-16\n"
+     ]
+    }
+   ],
    "source": [
     "s.run()"
    ]
@@ -543,18 +1237,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['weather_data.json']"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "os.listdir(os.path.join(output_weather_location, \"2018-06-16\",\"JSON\",\"WEATHER\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'mean_2m_air_temperature': 302.51324462890625, 'total_precipitation': 0.04973767697811127}\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "j=json.load(open(os.path.join(output_weather_location, \"2018-06-16\",\"JSON\",\"WEATHER\",\"weather_data.json\")))\n",
@@ -571,9 +1284,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "veg",
    "language": "python",
-   "name": "python3"
+   "name": "veg"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pyveg/scripts/analyse_gee_data.py
+++ b/pyveg/scripts/analyse_gee_data.py
@@ -343,9 +343,17 @@ def analyse_gee_data(input_location,
 
             try:
                 metadata = input_json["metadata"] if "metadata" in input_json.keys() else None
+
+                if input_location_type=='local':
+                    from pathlib import Path
+
+                    parent_path = Path(input_location).parent
+                    rgb_location = parent_path
+                else:
+                    rgb_location = input_location
                 create_markdown_pdf_report(output_dir,
                                            "local",
-                                           input_location,
+                                           rgb_location,
                                            input_location_type,
                                            do_time_series,
                                            output_dir,

--- a/pyveg/scripts/create_analysis_report.py
+++ b/pyveg/scripts/create_analysis_report.py
@@ -91,6 +91,23 @@ def add_time_series_plots(mdFile, analysis_plots_location, analysis_plots_locati
         mdFile.new_line(
         mdFile.new_inline_image(text='EWS NDVI', path=os.path.join(ews_path, satellite_suffix+'-ndvi-mean-ews.png')))
         mdFile.new_line('')
+
+    mdFile.new_header(level=1, title='Average annual time series CB fit')
+    fig_count += 1
+    mdFile.new_line(
+        mdFile.new_inline_image(text='Offset50 CB fit', path=os.path.join(analysis_plots_location,'analysis', 'fit_ts_CB_S2_offset50_mean.png')))
+    mdFile.new_line('')
+    fig_count += 1
+    mdFile.new_line(
+        mdFile.new_inline_image(text='NDVI CB fit',
+                                path=os.path.join(analysis_plots_location, 'analysis','fit_ts_CB_S2_ndvi_mean.png')))
+    mdFile.new_line('')
+    fig_count += 1
+    mdFile.new_line(
+        mdFile.new_inline_image(text='total precipitation CB fit',
+                                path=os.path.join(analysis_plots_location, 'analysis','fit_ts_CB_total_precipitation.png')))
+    mdFile.new_line('')
+
     return mdFile, fig_count
 
 
@@ -100,7 +117,7 @@ def add_rgb_images(mdFile, rgb_location, rgb_location_type, fig_count):
     if rgb_location_type == "local":
         for root, dirs, files in os.walk(rgb_location):
             for filename in files:
-                if filename.endswith("RGB.png"):
+                if filename.endswith("RGB.png") and os.path.basename(filename).startswith('sub')==False:
                     rgb_filenames.append(os.path.join(rgb_location, root, filename))
     elif rgb_location_type == "azure":
         tmpdir = tempfile.mkdtemp()
@@ -149,8 +166,6 @@ def create_markdown_pdf_report(analysis_plots_location,
 
     if metadata:
         coordinates = (metadata['longitude'], metadata['latitude'])
-    else:
-        coordinates = find_coords_from_path(analysis_plots_location, rgb_location)
     if not coordinates:
         raise RuntimeError("Unable to find coordinates from path.  Please provide a metadata dict.")
 
@@ -181,7 +196,7 @@ def create_markdown_pdf_report(analysis_plots_location,
     mdFile.new_table_of_contents(table_title='Contents', depth=2)
     mdFile.create_md_file()
 
-
+    print ('Converting to pdf.')
     output = pypandoc.convert_file(output_path+'.md', 'pdf', outputfile=output_path+".pdf")
     assert output == ""
 

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -15,7 +15,7 @@ import ewstools
 
 from statsmodels.nonparametric.smoothers_lowess import lowess
 
-from pyveg.src.data_analysis_utils import write_to_json
+from pyveg.src.data_analysis_utils import write_to_json, cball_parfit, cball
 
 from pyveg.src.date_utils import get_time_diff
 
@@ -1039,6 +1039,17 @@ def save_ts_summary_stats(ts_dirname, output_dir, metadata):
 
             column_dict = get_ts_summary_stats(ts_df[column])
             column_dict['ts_id'] = column
+
+            # make sure is a dated time series for resampling later in the CB calculation
+            ts_df[column].index = pd.DatetimeIndex(ts_df['date'])
+            cb_params, sucess, residuals = cball_parfit([1.5, 150.0, 8.0, 2.0],ts_df[column],column, output_dir)
+            column_dict['CB_fit_success'] = sucess
+            column_dict['CB_fit_residuals'] = residuals
+            column_dict['CB_fit_alpha'] = cb_params[0]
+            column_dict['CB_fit_N'] = cb_params[1]
+            column_dict['CB_fit_xbar'] = cb_params[2]
+            column_dict['CB_fit_sigma'] = cb_params[3]
+
             for key in metadata:
                 column_dict[key] = metadata[key]
 

--- a/pyveg/src/data_analysis_utils.py
+++ b/pyveg/src/data_analysis_utils.py
@@ -1330,7 +1330,7 @@ def cball_parfit(p0, timeseries):
     Parameters
     ----------
     p0 : Initial parameters, list
-        A list a parameters to use in the Crystal Ball calculation as an initial estimate
+        A list a parameters (alpha, n, xbar, sigma) to use in the Crystal Ball calculation as an initial estimate
 
     timeseries : Time series
         Original time series to calculate mean annual time series on, reverse and normalise

--- a/pyveg/src/data_analysis_utils.py
+++ b/pyveg/src/data_analysis_utils.py
@@ -25,7 +25,6 @@ import ewstools
 import scipy
 import scipy.optimize as sco
 
-
 def convert_to_geopandas(df):
     """
     Given a pandas DatFrame with `lat` and `long` columns, convert
@@ -1322,7 +1321,7 @@ def err_func(params, ts):
     return residuals
 
 
-def cball_parfit(p0, timeseries):
+def cball_parfit(p0, timeseries, plot_name = 'CB_fit.png', output_dir = ''):
     """
     Uses least squares regression to optimise the parameters in cball to fit the
     timeseries supplied. The supplied time series should be the original series
@@ -1335,16 +1334,59 @@ def cball_parfit(p0, timeseries):
     timeseries : Time series
         Original time series to calculate mean annual time series on, reverse and normalise
         and then use to optimise the parameters on
+    plot_name: string
+        Name for the data/fit comparison plot
+    output_dir : str
+            Directory to save the plots in.
     Returns
     ----------
     ndarray
         A list of optimised parameters (alpha, n, xbar, sigma)
     int
         A indication that the optimisation works (if output is 1,2,3 or 4 then ok)
+    float
+        The residuals from the best CB fit
     """
+    try:
+        mean_ts= timeseries.groupby(timeseries.index.month).mean()
 
-    mean_ts = mean_annual_ts(timeseries)
+        if min(mean_ts)<0 and max(mean_ts)<0:
+            mean_ts = mean_ts - min(mean_ts)
+            p0 = [1.5,150,8.5,1.1]
+    except:
+        raise RuntimeError('Input time series for CB fit must have a datetime index')
+
+
     ts = reverse_normalise_ts(mean_ts)
-    p1, success = sco.leastsq(err_func, p0, args=ts)
-    return p1, success
+
+    residuals_min = 1
+    for i in range(5):
+        params, success = sco.leastsq(err_func, p0, args=ts)
+        residuals = sum(err_func(params, ts))
+        plt.plot(ts, 'k.', label='data')
+        plt.plot(cball(range(1, len(ts) + 1), params[0], params[1], params[2], params[3]), 'r',
+                 label='Crystal ball fit', linewidth=1)
+        if residuals < residuals_min:
+            residuals_min = residuals
+            p0 = params
+            final_params = params
+            final_sucess = success
+
+    fig, ax = plt.subplots()
+    plt.plot(ts, 'k.', label='data')
+    plt.plot(cball(range(1, len(ts) + 1), final_params[0], final_params[1], final_params[2], final_params[3]), 'r', label='Crystal ball fit', linewidth=1)
+    plt.legend(loc='upper right')
+    ax.set_xticks(np.arange(len(ts)))
+    labels = ['Dec', 'Nov','Oct','Sep','Aug','Jul','Jun','May','Apr','Mar','Feb','Jan']
+    ax.set_xticklabels(labels)
+    # Rotate the tick labels and set their alignment.
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right",
+             rotation_mode="anchor")
+
+    plt.xlabel('Month (reversed)')
+    plt.ylabel('PDF')
+    plt.title('Crystal ball fit for ' + plot_name)
+    plt.savefig(os.path.join(output_dir, "fit_ts_CB_"+plot_name+".png"))
+
+    return final_params, final_sucess, residuals_min
 


### PR DESCRIPTION
Closes #455 

Changes:

- [x] Updating text to document order on the input parameters 
- [x] Run CB fit on the time series for the summary statistics
    - Replaced function that estimated the mean annual time series
    - Given that fit is very sensitive to input parameter ran the fit minisation several times in a loop, keeping the one returning the smallest residuals and using the output of the fit as input parameter for the next iteration. 
- [x] Save a plot of the data/fit comparison
- [x] Return CB parameters and fit quality to the summary statics
    - best parameters for: alpha, n , xbar, sigma, success and residuals.

Other business:

- [x] Fix issue with running analysis locally and not finding RGB images. 
- [x] Included CB fit plots in the report
