### PR TITLE
Feature/470 seasonal ar1 summary

### DIFF
--- a/pyveg/README.md
+++ b/pyveg/README.md
@@ -180,6 +180,9 @@ pyveg_gee_analysis --input_dir <path_to_pyveg_download_output_dir>
 ```
 The analysis code preprocesses the data and produces a number of plots. These will be saved in an `analysis/` subdirectory inside the `<path_to_pyveg_download_output_dir>` directory.
 
+Note that in order to have a meaningful analysis, the dowloaded time series should have at least 4 points (and more thant 12
+for an early warning analysis) and not being the result of a "test" config file, in this case the analysis fails.
+ 
 The commands also allows for other options to be added to the execution of the script (e.g. run analysis from a downloaded data in Azure blob storage, define a different output directly, don't include a time series analysis, etc), which can be displayed by typing:
 
 ```

--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -1066,7 +1066,27 @@ def save_ts_summary_stats(ts_dirname, output_dir, metadata):
                 column_dict["Kendall tau Lag-1 AC (0.5 rolling window)"] = Kendall_tau_50["Lag-1 AC"].iloc[-1]
                 column_dict["Kendall tau Variance (0.5 rolling window)"] = Kendall_tau_50["Variance"].iloc[-1]
 
+                # We also want the AR1 and Standard deviation of the raw seasonal timeseries for the summary stats
+                if ts_df.empty == False:
+                    ews_dic_veg_seasonal = ewstools.core.ews_compute(ts_df[column].dropna(),
+                                                            roll_window=0.99,
+                                                            smooth='None',
+                                                            lag_times=[1],
+                                                            ews=["var", "ac"])
 
+                    EWSmetrics_df_seasonal = ews_dic_veg_seasonal['EWS metrics']
+                    column_dict["Lag-1 AC (0.99 rolling window) Seasonal"] = EWSmetrics_df_seasonal["Lag-1 AC"].iloc[-1]
+                    column_dict["Variance (0.99 rolling window)  Seasonal"] = EWSmetrics_df_seasonal["Variance"].iloc[-1]
+
+                    ews_dic_veg_50_seasonal = ewstools.core.ews_compute(ts_df[column].dropna(),
+                                                               roll_window=0.5,
+                                                               smooth='None',
+                                                               lag_times=[1],
+                                                               ews=["var", "ac"])
+
+                    Kendall_tau_50_seasonal = ews_dic_veg_50_seasonal['Kendall tau']
+                    column_dict["Kendall tau Lag-1 AC (0.5 rolling window) Seasonal"] = Kendall_tau_50_seasonal["Lag-1 AC"].iloc[-1]
+                    column_dict["Kendall tau Variance (0.5 rolling window) Seasonal"] = Kendall_tau_50_seasonal["Variance"].iloc[-1]
 
             ts_dict_list.append(column_dict)
 


### PR DESCRIPTION
Fixes #470 

Run ews to seasonal time series, saves the following new variables to the summary_stats_dataframe:

- Lag-1 AC (0.99   rolling window) Seasonal 
- Variance (0.99 rolling window)  Seasonal 
* Kendall tau Lag-1 AC (0.5 rolling window)   Seasonal 
* Kendall tau   Variance (0.5 rolling window) Seasonal


