### PR TITLE
Bugfix/fix ci

### DIFF
--- a/pyveg/src/analysis_preprocessing.py
+++ b/pyveg/src/analysis_preprocessing.py
@@ -1056,7 +1056,7 @@ def save_ts_summary_stats(ts_dirname, output_dir, metadata):
             # We want the AR1 and Standard deviation of the detreded timeseries for the summary stats
             if ts_df_detrended.empty==False:
                 ews_dic_veg = ewstools.core.ews_compute(ts_df_detrended[column].dropna(),
-                                                        roll_window=0.99 ,
+                                                        roll_window=0.999 ,
                                                         smooth='Gaussian',
                                                         lag_times=[1],
                                                         ews= ["var", "ac"],
@@ -1079,8 +1079,11 @@ def save_ts_summary_stats(ts_dirname, output_dir, metadata):
 
                 # We also want the AR1 and Standard deviation of the raw seasonal timeseries for the summary stats
                 if ts_df.empty == False:
-                    ews_dic_veg_seasonal = ewstools.core.ews_compute(ts_df[column].dropna(),
-                                                            roll_window=0.99,
+                    # make sure in this case that the index is numeric
+                    ts = ts_df[column].dropna()
+                    ts.index = pd.to_numeric(ts.index)
+                    ews_dic_veg_seasonal = ewstools.core.ews_compute(ts,
+                                                            roll_window=0.999,
                                                             smooth='None',
                                                             lag_times=[1],
                                                             ews=["var", "ac"])
@@ -1089,7 +1092,7 @@ def save_ts_summary_stats(ts_dirname, output_dir, metadata):
                     column_dict["Lag-1 AC (0.99 rolling window) Seasonal"] = EWSmetrics_df_seasonal["Lag-1 AC"].iloc[-1]
                     column_dict["Variance (0.99 rolling window)  Seasonal"] = EWSmetrics_df_seasonal["Variance"].iloc[-1]
 
-                    ews_dic_veg_50_seasonal = ewstools.core.ews_compute(ts_df[column].dropna(),
+                    ews_dic_veg_50_seasonal = ewstools.core.ews_compute(ts,
                                                                roll_window=0.5,
                                                                smooth='None',
                                                                lag_times=[1],


### PR DESCRIPTION
Running the ews on the seasonal time series for the summary statistics broke the CI, because the index of the time series was a 'datetime' object and not numerical as expected in the ews tool. 

That is fixed in this PR by casting the index into numerical.